### PR TITLE
fix: guard crypto usage when adding parameter

### DIFF
--- a/src/components/config/config-form.tsx
+++ b/src/components/config/config-form.tsx
@@ -128,9 +128,20 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
     });
   };
 
+  // Generate a unique id for a new parameter. Some environments (or older
+  // browsers) don't provide `crypto.randomUUID`, which previously resulted in a
+  // runtime error when adding a parameter. We fall back to a simple random
+  // string in those cases.
+  const generateId = () => {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return crypto.randomUUID();
+    }
+    return Math.random().toString(36).slice(2);
+  };
+
   const handleAddParameter = () => {
     append({
-      id: crypto.randomUUID(),
+      id: generateId(),
       name: '',
       unit: '',
       description: '',


### PR DESCRIPTION
## Summary
- avoid runtime error in ConfigForm when crypto.randomUUID is unavailable by adding generateId fallback

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: Argument of type 'Promise<ReadonlyRequestCookies>' is not assignable to parameter of type 'CookieStore'; Type 'T' does not satisfy the constraint 'Document')*


------
https://chatgpt.com/codex/tasks/task_e_68c094c015dc8325826e9364ff840f1c