### PR TITLE
Handle promised params in dashboard and config pages

### DIFF
--- a/src/app/config/edit/[name]/page.tsx
+++ b/src/app/config/edit/[name]/page.tsx
@@ -3,13 +3,14 @@ import { ConfigForm } from '@/components/config/config-form';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 type EditConfigurationPageProps = {
-  params: {
+  params: Promise<{
     name: string;
-  };
+  }>;
 };
 
 export default async function EditConfigurationPage({ params }: EditConfigurationPageProps) {
-  const configName = decodeURIComponent(params.name);
+  const { name } = await params;
+  const configName = decodeURIComponent(name);
   const config = await getConfiguration(configName);
 
   return (

--- a/src/app/dashboard/[name]/page.tsx
+++ b/src/app/dashboard/[name]/page.tsx
@@ -4,13 +4,14 @@ import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 
 type DisplayDashboardPageProps = {
-  params: {
+  params: Promise<{
     name: string;
-  };
+  }>;
 };
 
 export default async function DisplayDashboardPage({ params }: DisplayDashboardPageProps) {
-  const configName = decodeURIComponent(params.name);
+  const { name } = await params;
+  const configName = decodeURIComponent(name);
   const config = await getConfiguration(configName);
 
   if (config.parameters.length === 0) {


### PR DESCRIPTION
## Summary
- Accept async route params in dashboard page and decode name after awaiting
- Accept async route params in configuration edit page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires Next.js ESLint plugin setup)*
- `npm run typecheck` *(fails: TS2344 in src/lib/mongodb.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e9e290ec8325a28d4acd6f4fdced