### PR TITLE
Add local MongoDB config file and fix type check

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+MONGODB_URI="mongodb://localhost:27017"

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!.env.local
 
 # firebase
 firebase-debug.log

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -1,4 +1,4 @@
-import { MongoClient, Db, Collection } from 'mongodb';
+import { MongoClient, Db, Collection, Document } from 'mongodb';
 
 const uri = process.env.MONGODB_URI;
 const dbName = 'smart-monitoring-db'; // You can change this to your preferred database name
@@ -38,7 +38,9 @@ async function connectToDatabase() {
   }
 }
 
-export async function getCollection<T>(collectionName: string): Promise<Collection<T> | null> {
+export async function getCollection<T extends Document>(
+  collectionName: string,
+): Promise<Collection<T> | null> {
   if (!isMongoConfigured()) {
     return null;
   }


### PR DESCRIPTION
## Summary
- add `.env.local` with a localhost MongoDB URI for development
- allow `.env.local` to be committed and constrain MongoDB helper generic to `Document`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(requires interactive setup, not run)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c1e9690fc48325afd8c7202f5ceff9