### PR TITLE
refactor: pass session to header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default async function RootLayout({
       </head>
       <body className={cn('min-h-screen bg-background font-body antialiased')}>
             <div className="relative flex min-h-screen flex-col">
-                {(session.isLoggedIn || !isDbConnected) && <AppHeader />}
+                {(session.isLoggedIn || !isDbConnected) && <AppHeader session={session} />}
                 <main className="flex-1">{children}</main>
             </div>
             <Toaster />

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -7,14 +7,16 @@ import { cn } from '@/lib/utils';
 import { PanelsTopLeft } from 'lucide-react';
 import { LocationTime } from './location-time';
 import { UserNav } from './user-nav';
-import { useSession } from '@/hooks/use-session';
+import { SessionData } from '@/lib/session';
 
+interface AppHeaderProps {
+  session: SessionData;
+}
 
-export function AppHeader() {
+export function AppHeader({ session }: AppHeaderProps) {
   const pathname = usePathname();
-  const { session } = useSession();
-  
-  const navLinks = session?.role === 'admin'
+
+  const navLinks = session.role === 'admin'
     ? [
         { href: '/dashboard', label: 'Dashboard' },
         { href: '/config', label: 'Configuration' },
@@ -22,17 +24,10 @@ export function AppHeader() {
       ]
     : [
         {
-          href: `/dashboard/${encodeURIComponent(session?.dashboardName || '')}`,
+          href: `/dashboard/${encodeURIComponent(session.dashboardName ?? '')}`,
           label: 'Dashboard',
         },
       ];
-
-  // If not logged in and no DB, don't show the header
-  if (!session?.isLoggedIn && !process.env.NEXT_PUBLIC_IS_DEMO) {
-      const isDbConfigured = !!process.env.MONGODB_URI;
-      if (isDbConfigured) return null;
-  }
-
 
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">


### PR DESCRIPTION
## Summary
- simplify `AppHeader` by passing session as props and removing env-based conditional
- inject server session via `RootLayout` and gate header rendering there

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c292b290888325ac9de113ccec1beb