### PR TITLE
Use dashboardNames array across user and session types

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -37,7 +37,7 @@ async function ensureDefaultUser() {
         const defaultUser: User = {
             username: 'admin',
             password: 'password', // In a real app, hash this!
-            dashboardName: 'Main Dashboard',
+            dashboardNames: ['Main Dashboard'],
             role: 'admin',
         };
         await userCollection.insertOne(defaultUser);
@@ -61,7 +61,7 @@ export async function login(credentials: z.infer<typeof LoginSchema>) {
             await setSession({
                 isLoggedIn: true,
                 username: 'admin',
-                dashboardName: 'Main Dashboard',
+                dashboardNames: ['Main Dashboard'],
                 role: 'admin',
             });
             revalidatePath('/', 'layout');
@@ -97,7 +97,7 @@ export async function login(credentials: z.infer<typeof LoginSchema>) {
     await setSession({
         isLoggedIn: true,
         username: user.username,
-        dashboardName: user.dashboardName,
+        dashboardNames: user.dashboardNames,
         role: user.role,
     });
     

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -26,7 +26,7 @@ export async function setSession(data: Partial<SessionData>) {
     const ironSession = await getIronSession<SessionData>(cookieStore, sessionOptions);
     ironSession.isLoggedIn = session.isLoggedIn;
     ironSession.username = session.username;
-    ironSession.dashboardName = session.dashboardName;
+    ironSession.dashboardNames = session.dashboardNames;
     ironSession.role = session.role;
     await ironSession.save();
 }

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -101,7 +101,7 @@ export default function AccountsHubPage() {
                         <Users className="h-5 w-5 text-primary" />
                         <div>
                             <p className="font-medium">{user.username}</p>
-                            <p className="text-sm text-muted-foreground">Dashboard: {user.dashboardName}</p>
+                            <p className="text-sm text-muted-foreground">Dashboard: {user.dashboardNames.join(', ')}</p>
                             <p className="text-sm text-muted-foreground capitalize">Role: {user.role}</p>
                         </div>
                       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,8 @@ import { getSession } from '@/actions/session';
 
 export default async function HomePage() {
     const session = await getSession();
-    if (session.isLoggedIn && session.dashboardName) {
-        redirect(`/dashboard/${encodeURIComponent(session.dashboardName)}`);
+    if (session.isLoggedIn && session.dashboardNames.length > 0) {
+        redirect(`/dashboard/${encodeURIComponent(session.dashboardNames[0])}`);
     }
     // For users without a session or DB, redirect to the main dashboard selector
     redirect('/dashboard');

--- a/src/components/accounts/account-form.tsx
+++ b/src/components/accounts/account-form.tsx
@@ -27,7 +27,7 @@ export function AccountForm({ dashboardNames }: AccountFormProps) {
     defaultValues: {
       username: '',
       password: '',
-      dashboardName: '',
+      dashboardNames: [],
       role: 'user',
     },
   });
@@ -87,11 +87,11 @@ export function AccountForm({ dashboardNames }: AccountFormProps) {
         />
         <FormField
           control={form.control}
-          name="dashboardName"
+          name="dashboardNames"
           render={({ field }) => (
             <FormItem>
               <FormLabel>Assigned Dashboard</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select onValueChange={(value) => field.onChange([value])} defaultValue={field.value[0]}>
                 <FormControl>
                   <SelectTrigger>
                     <SelectValue placeholder="Select a dashboard to assign" />
@@ -110,7 +110,7 @@ export function AccountForm({ dashboardNames }: AccountFormProps) {
                 </SelectContent>
               </Select>
                <FormDescription>
-                The user will only be able to see this dashboard.
+                The user will only be able to see these dashboards.
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -24,7 +24,7 @@ export function AppHeader({ session }: AppHeaderProps) {
       ]
     : [
         {
-          href: `/dashboard/${encodeURIComponent(session.dashboardName ?? '')}`,
+          href: `/dashboard/${encodeURIComponent(session.dashboardNames[0] ?? '')}`,
           label: 'Dashboard',
         },
       ];

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 export const SessionDataSchema = z.object({
   isLoggedIn: z.boolean().default(false),
   username: z.string().optional(),
-  dashboardName: z.string().optional(),
+  dashboardNames: z.array(z.string()).default([]),
   role: z.enum(['admin', 'user']).default('user'),
 });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,7 +21,7 @@ export type Config = z.infer<typeof ConfigSchema>;
 export const UserSchema = z.object({
   username: z.string().min(1, 'Username is required.'),
   password: z.string().min(6, 'Password must be at least 6 characters.'),
-  dashboardName: z.string().min(1, 'A dashboard must be assigned.'),
+  dashboardNames: z.array(z.string()),
   role: z.enum(['admin', 'user']).default('user'),
 });
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,19 +22,22 @@ export async function middleware(req: NextRequest) {
     const isAdmin = session.role === 'admin';
     if (publicRoutes.includes(path)) {
         // Redirect logged-in users away from public routes
-        const dashboardUrl = new URL(`/dashboard/${encodeURIComponent(session.dashboardName || '')}`, req.nextUrl);
+        const defaultDashboard = session.dashboardNames[0] || '';
+        const dashboardUrl = new URL(`/dashboard/${encodeURIComponent(defaultDashboard)}`, req.nextUrl);
         return NextResponse.redirect(dashboardUrl);
     }
     if (!isAdmin) {
         // Restrict non-admin users from config, accounts, or dashboard selector
         if (path.startsWith('/config') || path.startsWith('/accounts') || path === '/dashboard') {
-            const dashboardUrl = new URL(`/dashboard/${encodeURIComponent(session.dashboardName || '')}`, req.nextUrl);
+            const defaultDashboard = session.dashboardNames[0] || '';
+            const dashboardUrl = new URL(`/dashboard/${encodeURIComponent(defaultDashboard)}`, req.nextUrl);
             return NextResponse.redirect(dashboardUrl);
         }
         if (path.startsWith('/dashboard/')) {
             const requestedDashboard = decodeURIComponent(path.split('/')[2]);
-            if (session.dashboardName && session.dashboardName !== requestedDashboard) {
-                const correctDashboardUrl = new URL(`/dashboard/${encodeURIComponent(session.dashboardName || '')}`, req.nextUrl);
+            if (session.dashboardNames.length > 0 && !session.dashboardNames.includes(requestedDashboard)) {
+                const defaultDashboard = session.dashboardNames[0] || '';
+                const correctDashboardUrl = new URL(`/dashboard/${encodeURIComponent(defaultDashboard)}`, req.nextUrl);
                 return NextResponse.redirect(correctDashboardUrl);
             }
         }


### PR DESCRIPTION
## Summary
- replace single `dashboardName` with `dashboardNames` array in user and session schemas
- adjust authentication, session handling, middleware, and account forms to handle multiple dashboards

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c2a3a865588325bab1afebcd7364ef