### PR TITLE
feat: support multiple dashboards in session

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -61,6 +61,7 @@ export async function login(credentials: z.infer<typeof LoginSchema>) {
             await setSession({
                 isLoggedIn: true,
                 username: 'admin',
+                // Grant access to the default dashboard when Mongo isn't configured
                 dashboardNames: ['Main Dashboard'],
                 role: 'admin',
             });
@@ -97,7 +98,8 @@ export async function login(credentials: z.infer<typeof LoginSchema>) {
     await setSession({
         isLoggedIn: true,
         username: user.username,
-        dashboardNames: user.dashboardNames,
+        // Copy dashboard names from the user record, defaulting to an empty array
+        dashboardNames: [...(user.dashboardNames || [])],
         role: user.role,
     });
     

--- a/src/actions/session.ts
+++ b/src/actions/session.ts
@@ -26,7 +26,8 @@ export async function setSession(data: Partial<SessionData>) {
     const ironSession = await getIronSession<SessionData>(cookieStore, sessionOptions);
     ironSession.isLoggedIn = session.isLoggedIn;
     ironSession.username = session.username;
-    ironSession.dashboardNames = session.dashboardNames;
+    // Store a copy of dashboard names to avoid mutation side effects
+    ironSession.dashboardNames = [...session.dashboardNames];
     ironSession.role = session.role;
     await ironSession.save();
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 export const SessionDataSchema = z.object({
   isLoggedIn: z.boolean().default(false),
   username: z.string().optional(),
+  // Names of dashboards the user can access
   dashboardNames: z.array(z.string()).default([]),
   role: z.enum(['admin', 'user']).default('user'),
 });


### PR DESCRIPTION
## Summary
- document `dashboardNames` in session data
- copy `dashboardNames` to avoid mutation when saving session
- ensure login populates `dashboardNames` from user data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`
- `npm run build` *(fails to connect to MongoDB but build outputs generated)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a5025fd4832586489fea6289db37