### PR TITLE
Restrict dashboard access for non-admin users

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,11 +1,19 @@
 import { getConfigurationNames } from '@/actions/config';
+import { getSession } from '@/actions/session';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ListChecks } from 'lucide-react';
 import Link from 'next/link';
 import { isMongoConfigured } from '@/lib/mongodb';
 
 export default async function DashboardPage() {
-    const dashboardNames = await getConfigurationNames();
+  const session = await getSession();
+  let dashboardNames = await getConfigurationNames();
+
+  if (session.role !== 'admin') {
+    dashboardNames = dashboardNames.filter((name) =>
+      session.dashboardNames.includes(name)
+    );
+  }
 
   if (!isMongoConfigured() && dashboardNames.length === 0) {
     // If mongo is not configured, we create a default dashboard link for demo purposes.

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -23,10 +23,11 @@ export function AppHeader({ session }: AppHeaderProps) {
         { href: '/accounts', label: 'Accounts' },
       ]
     : [
-        {
-          href: `/dashboard/${encodeURIComponent(session.dashboardNames[0] ?? '')}`,
-          label: 'Dashboard',
-        },
+        { href: '/dashboard', label: 'Dashboard' },
+        ...session.dashboardNames.map((name) => ({
+          href: `/dashboard/${encodeURIComponent(name)}`,
+          label: name,
+        })),
       ];
 
   return (


### PR DESCRIPTION
## Summary
- Link non-admin users to the dashboard index and list individual dashboard links
- Limit dashboard selection page to dashboards allowed in the session

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint must be installed)*
- `npm install eslint --no-save` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c2a7a2b1b08325bbd823f08cf1ee4c