### PR TITLE
Restrict dashboard access to authorized sessions

### DIFF
--- a/src/app/dashboard/[name]/page.tsx
+++ b/src/app/dashboard/[name]/page.tsx
@@ -1,6 +1,8 @@
 import { getConfiguration } from '@/actions/config';
+import { getSession } from '@/actions/session';
 import { WidgetGrid } from '@/components/display/widget-grid';
 import { Button } from '@/components/ui/button';
+import { redirect } from 'next/navigation';
 import Link from 'next/link';
 
 type DisplayDashboardPageProps = {
@@ -12,6 +14,12 @@ type DisplayDashboardPageProps = {
 export default async function DisplayDashboardPage({ params }: DisplayDashboardPageProps) {
   const { name } = await params;
   const configName = decodeURIComponent(name);
+  const session = await getSession();
+
+  if (session.role !== 'admin' && !session.dashboardNames.includes(configName)) {
+    redirect('/dashboard');
+  }
+
   const config = await getConfiguration(configName);
 
   if (config.parameters.length === 0) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,9 +35,12 @@ export async function middleware(req: NextRequest) {
         }
         if (path.startsWith('/dashboard/')) {
             const requestedDashboard = decodeURIComponent(path.split('/')[2]);
-            if (session.dashboardNames.length > 0 && !session.dashboardNames.includes(requestedDashboard)) {
-                const defaultDashboard = session.dashboardNames[0] || '';
-                const correctDashboardUrl = new URL(`/dashboard/${encodeURIComponent(defaultDashboard)}`, req.nextUrl);
+            if (!session.dashboardNames.includes(requestedDashboard)) {
+                const defaultDashboard = session.dashboardNames[0];
+                const redirectPath = defaultDashboard
+                    ? `/dashboard/${encodeURIComponent(defaultDashboard)}`
+                    : '/dashboard';
+                const correctDashboardUrl = new URL(redirectPath, req.nextUrl);
                 return NextResponse.redirect(correctDashboardUrl);
             }
         }


### PR DESCRIPTION
## Summary
- Ensure dashboard pages verify the requested dashboard against the current session before rendering
- Redirect non-admin users when middleware detects access to unauthorized dashboards

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint must be installed)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c2a8fbbb208325aaa844db1ea421a9