### PR TITLE
Ensure dashboard names are always arrays

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -17,7 +17,11 @@ export async function getUsers(): Promise<User[]> {
   }
   try {
     const users = await collection.find({}, { projection: { password: 0 } }).toArray(); // Don't send passwords to the client
-    return JSON.parse(JSON.stringify(users));
+    const sanitizedUsers: User[] = JSON.parse(JSON.stringify(users));
+    return sanitizedUsers.map((user) => ({
+      ...user,
+      dashboardNames: Array.isArray(user.dashboardNames) ? user.dashboardNames : [],
+    }));
   } catch (error) {
     console.error('Failed to get users:', error);
     return [];

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -101,7 +101,9 @@ export default function AccountsHubPage() {
                         <Users className="h-5 w-5 text-primary" />
                         <div>
                             <p className="font-medium">{user.username}</p>
-                            <p className="text-sm text-muted-foreground">Dashboard: {user.dashboardNames.join(', ')}</p>
+                            <p className="text-sm text-muted-foreground">
+                              Dashboards: {user.dashboardNames?.join(", ") ?? "N/A"}
+                            </p>
                             <p className="text-sm text-muted-foreground capitalize">Role: {user.role}</p>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- Safely display dashboard names on accounts page with optional chaining and fallback
- Default dashboardNames to an empty array when fetching users

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint must be installed: npm install --save-dev eslint; dependency install blocked: 403 Forbidden)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2ac1143dc8325baba89c56c858fce