### PR TITLE
Ensure dashboard names are always arrays

### DIFF
--- a/src/app/accounts/edit/[username]/page.tsx
+++ b/src/app/accounts/edit/[username]/page.tsx
@@ -1,0 +1,33 @@
+import { getConfigurationNames } from '@/actions/config';
+import { getUser } from '@/actions/users';
+import { AccountForm } from '@/components/accounts/account-form';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface EditAccountPageProps {
+  params: Promise<{ username: string }>;
+}
+
+export default async function EditAccountPage({ params }: EditAccountPageProps) {
+  const { username } = await params;
+  const decodedUsername = decodeURIComponent(username);
+  const user = await getUser(decodedUsername);
+  const dashboardNames = await getConfigurationNames();
+
+  if (!user) {
+    return <div className="container mx-auto py-10">User not found.</div>;
+  }
+
+  return (
+    <div className="container mx-auto py-10">
+      <Card>
+        <CardHeader>
+          <CardTitle>Edit User: {user.username}</CardTitle>
+          <CardDescription>Modify user details and dashboard assignments.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AccountForm dashboardNames={dashboardNames} initialUser={user} isCreating={false} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/accounts/new/page.tsx
+++ b/src/app/accounts/new/page.tsx
@@ -11,11 +11,11 @@ export default async function NewAccountPage() {
         <CardHeader>
           <CardTitle>Create New User Account</CardTitle>
           <CardDescription>
-            Create a new user and assign them to a dashboard.
+            Create a new user and assign dashboards to them.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <AccountForm dashboardNames={dashboardNames} />
+          <AccountForm dashboardNames={dashboardNames} isCreating={true} />
         </CardContent>
       </Card>
     </div>

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -18,7 +18,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { useToast } from '@/hooks/use-toast';
-import { Users, Trash2, Loader2 } from 'lucide-react';
+import { Users, Trash2, Loader2, Pencil } from 'lucide-react';
 import { User } from '@/lib/types';
 
 export default function AccountsHubPage() {
@@ -101,11 +101,18 @@ export default function AccountsHubPage() {
                         <Users className="h-5 w-5 text-primary" />
                         <div>
                             <p className="font-medium">{user.username}</p>
-                            <p className="text-sm text-muted-foreground">Dashboard: {user.dashboardNames.join(', ')}</p>
+                            <p className="text-sm text-muted-foreground">
+                              Dashboards: {user.dashboardNames?.join(", ") ?? "N/A"}
+                            </p>
                             <p className="text-sm text-muted-foreground capitalize">Role: {user.role}</p>
                         </div>
                       </div>
                       <div className="flex gap-2">
+                        <Button variant="outline" asChild>
+                          <Link href={`/accounts/edit/${encodeURIComponent(user.username)}`}>
+                            <Pencil />
+                          </Link>
+                        </Button>
                         <Button variant="destructive" onClick={() => handleDeleteClick(user.username)}>
                           <Trash2 />
                         </Button>


### PR DESCRIPTION
## Summary
- Safely display dashboard names on accounts page with optional chaining and fallback
- Default dashboardNames to an empty array when fetching users
- Add edit page and button for managing accounts
- Allow assigning multiple dashboards per user

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint must be installed: npm install --save-dev eslint)*
- `npm run typecheck`
- `npm run build` *(fails to connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ac1143dc8325baba89c56c858fce