### PR TITLE
Add control panel with threshold alerts

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -31,7 +31,7 @@ async function ensureDefaultUser() {
         const configCollection = await getCollection('configurations');
         const configCount = await configCollection?.countDocuments();
         if (configCount === 0) {
-            await createConfiguration({ name: 'Main Dashboard', parameters: [] });
+            await createConfiguration({ name: 'Main Dashboard', parameters: [], controls: [] });
         }
 
         const defaultUser: User = {

--- a/src/actions/config.ts
+++ b/src/actions/config.ts
@@ -15,7 +15,7 @@ export async function getConfiguration(configName: string): Promise<Config> {
   if (!collection) {
     // If mongo is not configured, return a default empty config for demo purposes.
     if (configName === 'Main Dashboard') {
-        return { name: 'Main Dashboard', parameters: [] };
+        return { name: 'Main Dashboard', parameters: [], controls: [] };
     }
     notFound();
   }
@@ -23,12 +23,13 @@ export async function getConfiguration(configName: string): Promise<Config> {
     const config = await collection.findOne({ name: configName });
     if (!config) {
        if (configName === 'Main Dashboard') {
-        return { name: 'Main Dashboard', parameters: [] };
+        return { name: 'Main Dashboard', parameters: [], controls: [] };
       }
       notFound();
     }
-    // Convert ObjectId to string for client-side usage if needed.
-    return JSON.parse(JSON.stringify(config));
+    // Convert ObjectId to string for client-side usage if needed and ensure controls default
+    const parsed = JSON.parse(JSON.stringify(config));
+    return { ...parsed, controls: parsed.controls ?? [] };
   } catch (error) {
     console.error(`Failed to load configuration '${configName}':`, error);
     notFound();

--- a/src/app/dashboard/[name]/page.tsx
+++ b/src/app/dashboard/[name]/page.tsx
@@ -1,6 +1,7 @@
 import { getConfiguration } from '@/actions/config';
 import { getSession } from '@/actions/session';
 import { WidgetGrid } from '@/components/display/widget-grid';
+import { DashboardControls } from '@/components/display/dashboard-controls';
 import { Button } from '@/components/ui/button';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
@@ -46,6 +47,7 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
             <Link href="/dashboard">Switch Dashboard</Link>
         </Button>
       </div>
+      <DashboardControls controls={config.controls} parameters={config.parameters} />
       <WidgetGrid parameters={config.parameters} />
     </div>
   );

--- a/src/components/config/config-form.tsx
+++ b/src/components/config/config-form.tsx
@@ -97,12 +97,18 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
       {
         name: '',
         parameters: [],
+        controls: [],
       },
   });
 
   const { fields, append, remove } = useFieldArray({
     control: form.control,
     name: 'parameters',
+  });
+
+  const { fields: controlFields, append: appendControl, remove: removeControl } = useFieldArray({
+    control: form.control,
+    name: 'controls',
   });
 
   const onSubmit = (data: Config) => {
@@ -147,6 +153,14 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
       description: '',
       displayType: 'stat',
       icon: 'Info', // Default icon
+    });
+  };
+
+  const handleAddControl = () => {
+    appendControl({
+      id: generateId(),
+      type: 'refresh',
+      label: '',
     });
   };
 
@@ -281,10 +295,95 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
           ))}
         </div>
 
+        <div className="space-y-4 mt-8">
+          {controlFields.map((field, index) => (
+            <Card key={field.id} className="relative">
+              <CardHeader>
+                <CardTitle>Control #{index + 1}</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name={`controls.${index}.type`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Type</FormLabel>
+                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select control type" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="refresh">Refresh Button</SelectItem>
+                          <SelectItem value="threshold">Threshold Input</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name={`controls.${index}.label`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Label</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Label" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                {form.watch(`controls.${index}.type`) === 'threshold' && (
+                  <FormField
+                    control={form.control}
+                    name={`controls.${index}.parameterId`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Parameter</FormLabel>
+                        <Select onValueChange={field.onChange} defaultValue={field.value}>
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select parameter" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {form.watch('parameters').map((param, i) => (
+                              <SelectItem key={param.id || i} value={param.id}>
+                                {param.name || `Parameter ${i + 1}`}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute top-4 right-4 text-destructive hover:text-destructive"
+                  onClick={() => removeControl(index)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
         <div className="flex flex-col sm:flex-row gap-4">
           <Button type="button" variant="outline" onClick={handleAddParameter}>
             <Plus className="mr-2 h-4 w-4" />
             Add Parameter
+          </Button>
+          <Button type="button" variant="outline" onClick={handleAddControl}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add Control
           </Button>
         </div>
         

--- a/src/components/display/dashboard-controls.tsx
+++ b/src/components/display/dashboard-controls.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { Control, Parameter } from '@/lib/types';
+import { useParameterData } from '@/hooks/use-parameter-data';
+import { useToast } from '@/hooks/use-toast';
+import { cn } from '@/lib/utils';
+
+interface DashboardControlsProps {
+  controls: Control[];
+  parameters: Parameter[];
+}
+
+export function DashboardControls({ controls, parameters }: DashboardControlsProps) {
+  if (!controls.length) return null;
+
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle>Control Panel</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-wrap items-center gap-4">
+        {controls.map((control) => {
+          switch (control.type) {
+            case 'refresh':
+              return <RefreshControl key={control.id} control={control} />;
+            case 'threshold':
+              const parameter = parameters.find((p) => p.id === control.parameterId);
+              if (!parameter) return null;
+              return <ThresholdControl key={control.id} control={control} parameter={parameter} />;
+            default:
+              return null;
+          }
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+function RefreshControl({ control }: { control: Control }) {
+  const [active, setActive] = useState(false);
+
+  return (
+    <Button
+      variant="secondary"
+      className={cn(active && 'bg-green-600 text-white hover:bg-green-700')}
+      onClick={() => setActive((prev) => !prev)}
+    >
+      {control.label || 'Refresh'}
+    </Button>
+  );
+}
+
+interface ThresholdControlProps {
+  control: Control;
+  parameter: Parameter;
+}
+
+function ThresholdControl({ control, parameter }: ThresholdControlProps) {
+  const { toast } = useToast();
+  const { data } = useParameterData(parameter);
+  const [threshold, setThreshold] = useState<number | null>(null);
+  const [notified, setNotified] = useState(false);
+
+  const value = typeof data === 'number' ? data : data?.value;
+
+  useEffect(() => {
+    if (threshold === null || value === undefined) return;
+    if (value >= threshold && !notified) {
+      toast({
+        title: `${parameter.name} threshold reached`,
+        description: `${value.toFixed ? value.toFixed(1) : value} ≥ ${threshold}`,
+      });
+      setNotified(true);
+    } else if (value < threshold && notified) {
+      setNotified(false);
+    }
+  }, [value, threshold, notified, toast, parameter.name]);
+
+  return (
+    <div className="flex items-center gap-2">
+      <Label htmlFor={`control-${control.id}`}>{control.label || parameter.name}</Label>
+      <Input
+        id={`control-${control.id}`}
+        type="number"
+        className="w-24"
+        placeholder="0"
+        value={threshold ?? ''}
+        onChange={(e) => {
+          const val = e.target.value;
+          setThreshold(val ? parseFloat(val) : null);
+        }}
+      />
+    </div>
+  );
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,9 +11,19 @@ export const ParameterSchema = z.object({
 
 export type Parameter = z.infer<typeof ParameterSchema>;
 
+export const ControlSchema = z.object({
+  id: z.string().default(() => crypto.randomUUID()),
+  type: z.enum(['refresh', 'threshold']).default('refresh'),
+  label: z.string().optional(),
+  parameterId: z.string().optional(),
+});
+
+export type Control = z.infer<typeof ControlSchema>;
+
 export const ConfigSchema = z.object({
   name: z.string().min(1, 'Configuration name is required.'),
   parameters: z.array(ParameterSchema),
+  controls: z.array(ControlSchema).default([]),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;


### PR DESCRIPTION
## Summary
- show dashboard controls inside a Control Panel card with active-state buttons
- link threshold inputs to parameters and raise toast notifications when values exceed limits
- allow configuration of threshold controls by selecting an associated parameter

## Testing
- `npm test` *(missing script: "test")*
- `npm run lint` *(failed: ESLint must be installed: npm install --save-dev eslint)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c3db36cba08325823da199baf61e33