### PR TITLE
feat: add control panel card for dashboard

### DIFF
--- a/src/components/display/dashboard-controls.tsx
+++ b/src/components/display/dashboard-controls.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { Control } from '@/lib/types';
 
 interface DashboardControlsProps {
@@ -13,26 +14,31 @@ export function DashboardControls({ controls }: DashboardControlsProps) {
   if (!controls.length) return null;
 
   return (
-    <div className="mb-6 flex flex-wrap items-center gap-4">
-      {controls.map((control) => {
-        switch (control.type) {
-          case 'refresh':
-            return (
-              <Button key={control.id} variant="secondary">
-                {control.label || 'Refresh'}
-              </Button>
-            );
-          case 'threshold':
-            return (
-              <div key={control.id} className="flex items-center gap-2">
-                <Label htmlFor={`control-${control.id}`}>{control.label || 'Threshold'}</Label>
-                <Input id={`control-${control.id}`} type="number" className="w-24" placeholder="0" />
-              </div>
-            );
-          default:
-            return null;
-        }
-      })}
-    </div>
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle>Control Panel</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-wrap items-center gap-4">
+        {controls.map((control) => {
+          switch (control.type) {
+            case 'refresh':
+              return (
+                <Button key={control.id} variant="secondary">
+                  {control.label || 'Refresh'}
+                </Button>
+              );
+            case 'threshold':
+              return (
+                <div key={control.id} className="flex items-center gap-2">
+                  <Label htmlFor={`control-${control.id}`}>{control.label || 'Threshold'}</Label>
+                  <Input id={`control-${control.id}`} type="number" className="w-24" placeholder="0" />
+                </div>
+              );
+            default:
+              return null;
+          }
+        })}
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- style dashboard controls inside a card as a control panel for buttons and threshold inputs

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5c360ef808325bcb785f8189f2bc5