### PR TITLE
feat: add control panel card for dashboard

### DIFF
--- a/src/app/dashboard/[name]/page.tsx
+++ b/src/app/dashboard/[name]/page.tsx
@@ -47,7 +47,7 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
             <Link href="/dashboard">Switch Dashboard</Link>
         </Button>
       </div>
-      <DashboardControls controls={config.controls} />
+      <DashboardControls controls={config.controls} parameters={config.parameters} />
       <WidgetGrid parameters={config.parameters} />
     </div>
   );

--- a/src/components/display/dashboard-controls.tsx
+++ b/src/components/display/dashboard-controls.tsx
@@ -1,38 +1,127 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import type { Control } from '@/lib/types';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useToast } from '@/hooks/use-toast';
+import { useParameterData } from '@/hooks/use-parameter-data';
+import type { Control, Parameter } from '@/lib/types';
 
 interface DashboardControlsProps {
   controls: Control[];
+  parameters: Parameter[];
 }
 
-export function DashboardControls({ controls }: DashboardControlsProps) {
+export function DashboardControls({ controls, parameters }: DashboardControlsProps) {
+  const [activeButtons, setActiveButtons] = useState<Record<string, boolean>>({});
+
   if (!controls.length) return null;
 
+  const toggleButton = (id: string) => {
+    setActiveButtons((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
   return (
-    <div className="mb-6 flex flex-wrap items-center gap-4">
-      {controls.map((control) => {
-        switch (control.type) {
-          case 'refresh':
-            return (
-              <Button key={control.id} variant="secondary">
-                {control.label || 'Refresh'}
-              </Button>
-            );
-          case 'threshold':
-            return (
-              <div key={control.id} className="flex items-center gap-2">
-                <Label htmlFor={`control-${control.id}`}>{control.label || 'Threshold'}</Label>
-                <Input id={`control-${control.id}`} type="number" className="w-24" placeholder="0" />
-              </div>
-            );
-          default:
-            return null;
-        }
-      })}
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle>Control Panel</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-wrap items-center gap-4">
+        {controls.map((control) => {
+          switch (control.type) {
+            case 'refresh': {
+              const isActive = activeButtons[control.id];
+              return (
+                <Button
+                  key={control.id}
+                  variant={isActive ? 'default' : 'secondary'}
+                  aria-pressed={isActive}
+                  onClick={() => toggleButton(control.id)}
+                >
+                  {control.label || 'Refresh'}
+                </Button>
+              );
+            }
+            case 'threshold':
+              return (
+                <ThresholdControl
+                  key={control.id}
+                  controlId={control.id}
+                  label={control.label}
+                  parameters={parameters}
+                />
+              );
+            default:
+              return null;
+          }
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ThresholdControl({
+  controlId,
+  label,
+  parameters,
+}: {
+  controlId: string;
+  label?: string;
+  parameters: Parameter[];
+}) {
+  const { toast } = useToast();
+  const [selectedParamId, setSelectedParamId] = useState(parameters[0]?.id ?? '');
+  const [threshold, setThreshold] = useState<number>(0);
+  const [alerted, setAlerted] = useState(false);
+  const parameter = parameters.find((p) => p.id === selectedParamId);
+  const { data } = useParameterData(parameter!, null);
+
+  const currentValue = typeof data === 'number' ? data : data?.value;
+
+  useEffect(() => {
+    if (parameter && threshold && currentValue !== undefined && currentValue >= threshold && !alerted) {
+      toast({
+        title: 'Threshold reached',
+        description: `${parameter.name} has reached ${currentValue.toFixed?.(1) ?? currentValue}`,
+      });
+      setAlerted(true);
+    }
+  }, [parameter, threshold, currentValue, alerted, toast]);
+
+  useEffect(() => {
+    setAlerted(false);
+  }, [threshold, selectedParamId]);
+
+  if (!parameters.length) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Select value={selectedParamId} onValueChange={(val) => setSelectedParamId(val)}>
+        <SelectTrigger className="w-[160px]">
+          <SelectValue placeholder="Parameter" />
+        </SelectTrigger>
+        <SelectContent>
+          {parameters.map((p) => (
+            <SelectItem key={p.id} value={p.id}>
+              {p.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Label htmlFor={`control-${controlId}`} className="sr-only">
+        {label || 'Threshold'}
+      </Label>
+      <Input
+        id={`control-${controlId}`}
+        type="number"
+        className="w-24"
+        placeholder="0"
+        value={threshold ? threshold : ''}
+        onChange={(e) => setThreshold(Number(e.target.value))}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- style dashboard controls inside a card as a control panel for buttons and threshold inputs
- link thresholds to selectable parameters with alerts when values exceed limits
- show active state on control buttons

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5c360ef808325bcb785f8189f2bc5