### PR TITLE
feat: link threshold controls to parameters

### DIFF
--- a/src/app/dashboard/[name]/page.tsx
+++ b/src/app/dashboard/[name]/page.tsx
@@ -47,7 +47,7 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
             <Link href="/dashboard">Switch Dashboard</Link>
         </Button>
       </div>
-      <DashboardControls controls={config.controls} />
+      <DashboardControls controls={config.controls} parameters={config.parameters} />
       <WidgetGrid parameters={config.parameters} />
     </div>
   );

--- a/src/components/config/config-form.tsx
+++ b/src/components/config/config-form.tsx
@@ -101,7 +101,7 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
       },
   });
 
-  const { fields, append, remove } = useFieldArray({
+  const { fields: parameterFields, append, remove } = useFieldArray({
     control: form.control,
     name: 'parameters',
   });
@@ -184,7 +184,7 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
           )}
         />
         <div className="space-y-4">
-          {fields.map((field, index) => (
+          {parameterFields.map((field, index) => (
             <Card key={field.id} className="relative">
               <CardHeader>
                 <CardTitle>Parameter #{index + 1}</CardTitle>
@@ -336,6 +336,47 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
                     </FormItem>
                   )}
                 />
+                {form.watch(`controls.${index}.type`) === 'threshold' && (
+                  <>
+                    <FormField
+                      control={form.control}
+                      name={`controls.${index}.parameterId`}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Parameter</FormLabel>
+                          <Select onValueChange={field.onChange} defaultValue={field.value}>
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select parameter" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {parameterFields.map((p) => (
+                                <SelectItem key={p.id} value={p.id}>
+                                  {p.name || 'Unnamed'}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`controls.${index}.threshold`}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Threshold</FormLabel>
+                          <FormControl>
+                            <Input type="number" placeholder="0" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </>
+                )}
                 <Button
                   type="button"
                   variant="ghost"

--- a/src/components/display/dashboard-controls.tsx
+++ b/src/components/display/dashboard-controls.tsx
@@ -1,16 +1,46 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import type { Control } from '@/lib/types';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { useParameterData } from '@/hooks/use-parameter-data';
+import type { Control, Parameter } from '@/lib/types';
 
 interface DashboardControlsProps {
   controls: Control[];
+  parameters: Parameter[];
 }
 
-export function DashboardControls({ controls }: DashboardControlsProps) {
+function ThresholdControl({ control, parameter }: { control: Control; parameter: Parameter }) {
+  const { data: value } = useParameterData(parameter, 0);
+  const numericValue = typeof value === 'number' ? value : value?.value;
+  const isActive =
+    typeof numericValue === 'number' && control.threshold !== undefined
+      ? numericValue >= control.threshold
+      : false;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Label htmlFor={`control-${control.id}`}>{control.label || 'Threshold'}</Label>
+        <Button id={`control-${control.id}`} variant={isActive ? 'destructive' : 'secondary'}>
+          {isActive ? 'Active' : 'Inactive'}
+        </Button>
+      </div>
+      {isActive && (
+        <Alert variant="destructive">
+          <AlertTitle>Alert</AlertTitle>
+          <AlertDescription>
+            {parameter.name} reached {numericValue?.toFixed(1)} {parameter.unit}
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}
+
+export function DashboardControls({ controls, parameters }: DashboardControlsProps) {
   if (!controls.length) return null;
 
   return (
@@ -28,12 +58,9 @@ export function DashboardControls({ controls }: DashboardControlsProps) {
                 </Button>
               );
             case 'threshold':
-              return (
-                <div key={control.id} className="flex items-center gap-2">
-                  <Label htmlFor={`control-${control.id}`}>{control.label || 'Threshold'}</Label>
-                  <Input id={`control-${control.id}`} type="number" className="w-24" placeholder="0" />
-                </div>
-              );
+              const parameter = parameters.find((p) => p.id === control.parameterId);
+              if (!parameter) return null;
+              return <ThresholdControl key={control.id} control={control} parameter={parameter} />;
             default:
               return null;
           }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,8 @@ export const ControlSchema = z.object({
   id: z.string().default(() => crypto.randomUUID()),
   type: z.enum(['refresh', 'threshold']).default('refresh'),
   label: z.string().optional(),
+  parameterId: z.string().optional(),
+  threshold: z.number().optional(),
 });
 
 export type Control = z.infer<typeof ControlSchema>;


### PR DESCRIPTION
## Summary
- allow threshold controls to reference a parameter and limit value
- surface alert and active state when a parameter crosses its threshold

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm install --save-dev eslint` *(fails: 403 Forbidden)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5c601291c83258014e281bc58643b