### PR TITLE
fix: handle missing parameters in threshold controls

### DIFF
--- a/src/app/dashboard/[name]/page.tsx
+++ b/src/app/dashboard/[name]/page.tsx
@@ -47,7 +47,7 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
             <Link href="/dashboard">Switch Dashboard</Link>
         </Button>
       </div>
-      <DashboardControls controls={config.controls} />
+      <DashboardControls controls={config.controls} parameters={config.parameters} />
       <WidgetGrid parameters={config.parameters} />
     </div>
   );

--- a/src/components/config/config-form.tsx
+++ b/src/components/config/config-form.tsx
@@ -101,7 +101,7 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
       },
   });
 
-  const { fields, append, remove } = useFieldArray({
+  const { fields: parameterFields, append, remove } = useFieldArray({
     control: form.control,
     name: 'parameters',
   });
@@ -184,7 +184,7 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
           )}
         />
         <div className="space-y-4">
-          {fields.map((field, index) => (
+          {parameterFields.map((field, index) => (
             <Card key={field.id} className="relative">
               <CardHeader>
                 <CardTitle>Parameter #{index + 1}</CardTitle>
@@ -336,6 +336,47 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
                     </FormItem>
                   )}
                 />
+                {form.watch(`controls.${index}.type`) === 'threshold' && (
+                  <>
+                    <FormField
+                      control={form.control}
+                      name={`controls.${index}.parameterId`}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Parameter</FormLabel>
+                          <Select onValueChange={field.onChange} defaultValue={field.value}>
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select parameter" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {parameterFields.map((p) => (
+                                <SelectItem key={p.id} value={p.id}>
+                                  {p.name || 'Unnamed'}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`controls.${index}.threshold`}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Threshold</FormLabel>
+                          <FormControl>
+                            <Input type="number" placeholder="0" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </>
+                )}
                 <Button
                   type="button"
                   variant="ghost"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,8 @@ export const ControlSchema = z.object({
   id: z.string().default(() => crypto.randomUUID()),
   type: z.enum(['refresh', 'threshold']).default('refresh'),
   label: z.string().optional(),
+  parameterId: z.string().optional(),
+  threshold: z.number().optional(),
 });
 
 export type Control = z.infer<typeof ControlSchema>;


### PR DESCRIPTION
## Summary
- avoid runtime error by allowing DashboardControls to render without parameters

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5c601291c83258014e281bc58643b