### PR TITLE
Initialize threshold control values to avoid uncontrolled input warning

### DIFF
--- a/src/components/config/config-form.tsx
+++ b/src/components/config/config-form.tsx
@@ -308,17 +308,32 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>Type</FormLabel>
-                      <Select onValueChange={field.onChange} defaultValue={field.value}>
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select control type" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          <SelectItem value="refresh">Refresh Button</SelectItem>
-                          <SelectItem value="threshold">Threshold Input</SelectItem>
-                        </SelectContent>
-                      </Select>
+                        <Select
+                          onValueChange={(value) => {
+                            field.onChange(value);
+                            if (value === 'threshold') {
+                              form.setValue(
+                                `controls.${index}.parameterId`,
+                                form.getValues(`controls.${index}.parameterId`) ?? ''
+                              );
+                              form.setValue(
+                                `controls.${index}.threshold`,
+                                form.getValues(`controls.${index}.threshold`) ?? 0
+                              );
+                            }
+                          }}
+                          defaultValue={field.value}
+                        >
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select control type" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            <SelectItem value="refresh">Refresh Button</SelectItem>
+                            <SelectItem value="threshold">Threshold Input</SelectItem>
+                          </SelectContent>
+                        </Select>
                       <FormMessage />
                     </FormItem>
                   )}


### PR DESCRIPTION
## Summary
- ensure threshold controls initialize `parameterId` and `threshold` when switching to threshold type to avoid uncontrolled input warnings

## Testing
- `npm run lint` *(fails: npm not installed)*
- `npm run typecheck` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c907c9848325946f4ff4060ee2b4