### PR TITLE
Ensure threshold controls use numeric values

### DIFF
--- a/src/components/config/config-form.tsx
+++ b/src/components/config/config-form.tsx
@@ -316,9 +316,16 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
                                 `controls.${index}.parameterId`,
                                 form.getValues(`controls.${index}.parameterId`) ?? ''
                               );
+                              const currentThreshold = form.getValues(
+                                `controls.${index}.threshold`
+                              );
+                              const parsedThreshold =
+                                typeof currentThreshold === 'number'
+                                  ? currentThreshold
+                                  : Number(currentThreshold);
                               form.setValue(
                                 `controls.${index}.threshold`,
-                                form.getValues(`controls.${index}.threshold`) ?? 0
+                                Number.isNaN(parsedThreshold) ? 0 : parsedThreshold
                               );
                             }
                           }}
@@ -384,7 +391,13 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
                         <FormItem>
                           <FormLabel>Threshold</FormLabel>
                           <FormControl>
-                            <Input type="number" placeholder="0" {...field} />
+                            <Input
+                              {...field}
+                              type="number"
+                              placeholder="0"
+                              value={field.value ?? ''}
+                              onChange={(e) => field.onChange(e.target.valueAsNumber)}
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,7 +16,7 @@ export const ControlSchema = z.object({
   type: z.enum(['refresh', 'threshold']).default('refresh'),
   label: z.string().optional(),
   parameterId: z.string().optional(),
-  threshold: z.number().optional(),
+  threshold: z.coerce.number().optional(),
 });
 
 export type Control = z.infer<typeof ControlSchema>;


### PR DESCRIPTION
## Summary
- normalize threshold control defaults by coercing existing values and defaulting to zero when switching to threshold
- update the threshold input field to provide a defined value and pass numeric changes to react-hook-form
- allow threshold values in the schema to coerce from numeric strings

## Testing
- npm run lint *(fails: ESLint must be installed in this environment)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c83f49884c8325972096d5a63c9482