### PR TITLE
Ensure threshold controls use numeric values

### DIFF
--- a/src/components/config/config-form.tsx
+++ b/src/components/config/config-form.tsx
@@ -316,9 +316,16 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
                                 `controls.${index}.parameterId`,
                                 form.getValues(`controls.${index}.parameterId`) ?? ''
                               );
+                              const currentThreshold = form.getValues(
+                                `controls.${index}.threshold`
+                              );
+                              const parsedThreshold =
+                                typeof currentThreshold === 'number'
+                                  ? currentThreshold
+                                  : Number(currentThreshold);
                               form.setValue(
                                 `controls.${index}.threshold`,
-                                form.getValues(`controls.${index}.threshold`) ?? 0
+                                Number.isNaN(parsedThreshold) ? 0 : parsedThreshold
                               );
                             }
                           }}
@@ -384,7 +391,13 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
                         <FormItem>
                           <FormLabel>Threshold</FormLabel>
                           <FormControl>
-                            <Input type="number" placeholder="0" {...field} />
+                            <Input
+                              {...field}
+                              type="number"
+                              placeholder="0"
+                              value={field.value ?? ''}
+                              onChange={(e) => field.onChange(e.target.valueAsNumber)}
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/src/components/display/dashboard-controls.tsx
+++ b/src/components/display/dashboard-controls.tsx
@@ -3,7 +3,8 @@
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { useEffect } from 'react';
+import { useToast } from '@/hooks/use-toast';
 import { useParameterData } from '@/hooks/use-parameter-data';
 import type { Control, Parameter } from '@/lib/types';
 
@@ -15,10 +16,21 @@ interface DashboardControlsProps {
 function ThresholdControl({ control, parameter }: { control: Control; parameter: Parameter }) {
   const { data: value } = useParameterData(parameter, 0);
   const numericValue = typeof value === 'number' ? value : value?.value;
+  const { toast } = useToast();
   const isActive =
     typeof numericValue === 'number' && control.threshold !== undefined
       ? numericValue >= control.threshold
       : false;
+
+  useEffect(() => {
+    if (isActive) {
+      toast({
+        variant: 'destructive',
+        title: 'Alert',
+        description: `${parameter.name} reached ${numericValue?.toFixed(1)} ${parameter.unit}`,
+      });
+    }
+  }, [isActive, numericValue, parameter.name, parameter.unit, toast]);
 
   return (
     <div className="flex flex-col gap-2">
@@ -28,14 +40,6 @@ function ThresholdControl({ control, parameter }: { control: Control; parameter:
           {isActive ? 'Active' : 'Inactive'}
         </Button>
       </div>
-      {isActive && (
-        <Alert variant="destructive">
-          <AlertTitle>Alert</AlertTitle>
-          <AlertDescription>
-            {parameter.name} reached {numericValue?.toFixed(1)} {parameter.unit}
-          </AlertDescription>
-        </Alert>
-      )}
     </div>
   );
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,7 +16,7 @@ export const ControlSchema = z.object({
   type: z.enum(['refresh', 'threshold']).default('refresh'),
   label: z.string().optional(),
   parameterId: z.string().optional(),
-  threshold: z.number().optional(),
+  threshold: z.coerce.number().optional(),
 });
 
 export type Control = z.infer<typeof ControlSchema>;


### PR DESCRIPTION
## Summary
- normalize threshold control defaults by coercing existing values and defaulting to zero when switching to threshold
- update the threshold input field to provide a defined value and pass numeric changes to react-hook-form
- allow threshold values in the schema to coerce from numeric strings
- display a destructive toast when a parameter crosses its threshold

## Testing
- npm run lint *(fails: ESLint must be installed: npm install --save-dev eslint)*
- npm run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68c83f49884c8325972096d5a63c9482