### PR TITLE
Add vitest config and threshold control toast test

### DIFF
--- a/src/components/display/__tests__/dashboard-controls.test.tsx
+++ b/src/components/display/__tests__/dashboard-controls.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import type { Control, Parameter } from '@/lib/types';
+import { DashboardControls } from '../dashboard-controls';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const toastSpy = vi.fn();
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastSpy }),
+}));
+
+vi.mock('@/hooks/use-parameter-data', () => ({
+  useParameterData: () => ({ data: 55, isLoading: false, error: null }),
+}));
+
+afterEach(() => {
+  toastSpy.mockClear();
+  document.body.innerHTML = '';
+});
+
+describe('ThresholdControl', () => {
+  it('triggers a toast when the threshold is exceeded', async () => {
+    const control: Control = {
+      id: 'control-1',
+      type: 'threshold',
+      parameterId: 'parameter-1',
+      threshold: 50,
+      label: 'Temperature Threshold',
+    };
+
+    const parameter: Parameter = {
+      id: 'parameter-1',
+      name: 'Temperature',
+      unit: '°C',
+      displayType: 'stat',
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(<DashboardControls controls={[control]} parameters={[parameter]} />);
+      });
+
+      expect(toastSpy).toHaveBeenCalledTimes(1);
+      const toastPayload = toastSpy.mock.calls[0][0];
+      console.log('Toast message:', toastPayload.description);
+      expect(toastPayload).toMatchObject({
+        variant: 'destructive',
+        title: 'Alert',
+        description: 'Temperature reached 55.0 °C',
+      });
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      document.body.removeChild(container);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vitest configuration with an alias for the src directory and jsdom test environment
- create a dashboard controls test that mocks parameter data and toast usage to assert the destructive alert is triggered when the threshold is exceeded

## Testing
- `npx vitest run` *(fails: npm 403 forbidden when attempting to download vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68c87f0c7a1c832583da5b4d178b8aeb