### PR TITLE
Add toggle control type and modal dashboard panel

### DIFF
--- a/src/app/dashboard/[name]/page.tsx
+++ b/src/app/dashboard/[name]/page.tsx
@@ -43,11 +43,13 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
     <div className="container mx-auto py-10">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold">{config.name}</h1>
-         <Button asChild variant="outline">
+        <div className="flex items-center gap-2">
+          <DashboardControls controls={config.controls} parameters={config.parameters} />
+          <Button asChild variant="outline">
             <Link href="/dashboard">Switch Dashboard</Link>
-        </Button>
+          </Button>
+        </div>
       </div>
-      <DashboardControls controls={config.controls} parameters={config.parameters} />
       <WidgetGrid parameters={config.parameters} />
     </div>
   );

--- a/src/components/config/config-form.tsx
+++ b/src/components/config/config-form.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/hooks/use-toast';
 import {
   Cpu,
@@ -161,6 +162,7 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
       id: generateId(),
       type: 'refresh',
       label: '',
+      defaultState: false,
     });
   };
 
@@ -296,127 +298,174 @@ export function ConfigForm({ initialConfig, isCreating }: ConfigFormProps) {
         </div>
 
         <div className="space-y-4 mt-8">
-          {controlFields.map((field, index) => (
-            <Card key={field.id} className="relative">
-              <CardHeader>
-                <CardTitle>Control #{index + 1}</CardTitle>
-              </CardHeader>
-              <CardContent className="grid grid-cols-1 gap-6 md:grid-cols-2">
-                <FormField
-                  control={form.control}
-                  name={`controls.${index}.type`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Type</FormLabel>
-                        <Select
-                          onValueChange={(value) => {
-                            field.onChange(value);
-                            if (value === 'threshold') {
-                              form.setValue(
-                                `controls.${index}.parameterId`,
-                                form.getValues(`controls.${index}.parameterId`) ?? ''
-                              );
-                              const currentThreshold = form.getValues(
-                                `controls.${index}.threshold`
-                              );
-                              const parsedThreshold =
-                                typeof currentThreshold === 'number'
-                                  ? currentThreshold
-                                  : Number(currentThreshold);
-                              form.setValue(
-                                `controls.${index}.threshold`,
-                                Number.isNaN(parsedThreshold) ? 0 : parsedThreshold
-                              );
-                            }
-                          }}
-                          defaultValue={field.value}
-                        >
-                          <FormControl>
-                            <SelectTrigger>
-                              <SelectValue placeholder="Select control type" />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            <SelectItem value="refresh">Refresh Button</SelectItem>
-                            <SelectItem value="threshold">Threshold Input</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name={`controls.${index}.label`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Label</FormLabel>
-                      <FormControl>
-                        <Input placeholder="Label" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                {form.watch(`controls.${index}.type`) === 'threshold' && (
-                  <>
-                    <FormField
-                      control={form.control}
-                      name={`controls.${index}.parameterId`}
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Parameter</FormLabel>
-                          <Select onValueChange={field.onChange} defaultValue={field.value}>
+          {controlFields.map((controlField, index) => {
+            const controlType = form.watch(`controls.${index}.type`);
+
+            return (
+              <Card key={controlField.id} className="relative">
+                <CardHeader>
+                  <CardTitle>Control #{index + 1}</CardTitle>
+                </CardHeader>
+                <CardContent className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name={`controls.${index}.type`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Type</FormLabel>
+                          <Select
+                            onValueChange={(value) => {
+                              field.onChange(value);
+                              if (value === 'threshold') {
+                                form.setValue(
+                                  `controls.${index}.parameterId`,
+                                  form.getValues(`controls.${index}.parameterId`) ?? ''
+                                );
+                                const currentThreshold = form.getValues(
+                                  `controls.${index}.threshold`
+                                );
+                                const parsedThreshold =
+                                  typeof currentThreshold === 'number'
+                                    ? currentThreshold
+                                    : Number(currentThreshold);
+                                form.setValue(
+                                  `controls.${index}.threshold`,
+                                  Number.isNaN(parsedThreshold) ? 0 : parsedThreshold
+                                );
+                              } else {
+                                form.setValue(`controls.${index}.parameterId`, undefined);
+                                form.setValue(`controls.${index}.threshold`, undefined);
+                              }
+
+                              if (value === 'toggle') {
+                                const currentDefault = form.getValues(
+                                  `controls.${index}.defaultState`
+                                );
+                                form.setValue(
+                                  `controls.${index}.defaultState`,
+                                  typeof currentDefault === 'boolean' ? currentDefault : false
+                                );
+                              } else {
+                                form.setValue(`controls.${index}.defaultState`, undefined);
+                              }
+                            }}
+                            defaultValue={field.value}
+                          >
                             <FormControl>
                               <SelectTrigger>
-                                <SelectValue placeholder="Select parameter" />
+                                <SelectValue placeholder="Select control type" />
                               </SelectTrigger>
                             </FormControl>
                             <SelectContent>
-                              {parameterFields.map((p) => (
-                                <SelectItem key={p.id} value={p.id}>
-                                  {p.name || 'Unnamed'}
-                                </SelectItem>
-                              ))}
+                              <SelectItem value="refresh">Refresh Button</SelectItem>
+                              <SelectItem value="threshold">Threshold Input</SelectItem>
+                              <SelectItem value="toggle">Toggle Switch</SelectItem>
                             </SelectContent>
                           </Select>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name={`controls.${index}.label`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Label</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Label" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  {controlType === 'threshold' && (
+                    <>
+                      <FormField
+                        control={form.control}
+                        name={`controls.${index}.parameterId`}
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Parameter</FormLabel>
+                            <Select onValueChange={field.onChange} defaultValue={field.value}>
+                              <FormControl>
+                                <SelectTrigger>
+                                  <SelectValue placeholder="Select parameter" />
+                                </SelectTrigger>
+                              </FormControl>
+                              <SelectContent>
+                                {parameterFields.map((p) => (
+                                  <SelectItem key={p.id} value={p.id}>
+                                    {p.name || 'Unnamed'}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name={`controls.${index}.threshold`}
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Threshold</FormLabel>
+                            <FormControl>
+                              <Input
+                                {...field}
+                                type="number"
+                                placeholder="0"
+                                value={field.value ?? ''}
+                                onChange={(e) => field.onChange(e.target.valueAsNumber)}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </>
+                  )}
+                  {controlType === 'toggle' && (
                     <FormField
                       control={form.control}
-                      name={`controls.${index}.threshold`}
-                      render={({ field }) => (
+                      name={`controls.${index}.defaultState`}
+                      render={({ field: toggleField }) => (
                         <FormItem>
-                          <FormLabel>Threshold</FormLabel>
+                          <FormLabel>Default State</FormLabel>
                           <FormControl>
-                            <Input
-                              {...field}
-                              type="number"
-                              placeholder="0"
-                              value={field.value ?? ''}
-                              onChange={(e) => field.onChange(e.target.valueAsNumber)}
-                            />
+                            <div className="flex items-center gap-3">
+                              <Switch
+                                id={`control-${controlField.id}-default`}
+                                checked={toggleField.value ?? false}
+                                onCheckedChange={toggleField.onChange}
+                              />
+                              <span className="text-sm text-muted-foreground">
+                                {(toggleField.value ?? false) ? 'On' : 'Off'}
+                              </span>
+                            </div>
                           </FormControl>
+                          <FormDescription>
+                            Choose whether the toggle should be enabled by default.
+                          </FormDescription>
                           <FormMessage />
                         </FormItem>
                       )}
                     />
-                  </>
-                )}
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="absolute top-4 right-4 text-destructive hover:text-destructive"
-                  onClick={() => removeControl(index)}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
+                  )}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="absolute top-4 right-4 text-destructive hover:text-destructive"
+                    onClick={() => removeControl(index)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </CardContent>
+              </Card>
+            );
+          })}
         </div>
 
         <div className="flex flex-col sm:flex-row gap-4">

--- a/src/components/display/dashboard-controls.tsx
+++ b/src/components/display/dashboard-controls.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { useEffect } from 'react';
+import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/hooks/use-toast';
 import { useParameterData } from '@/hooks/use-parameter-data';
 import type { Control, Parameter } from '@/lib/types';
@@ -24,10 +26,6 @@ function ThresholdControl({ control, parameter }: { control: Control; parameter:
       : false;
 
   useEffect(() => {
-    console.log(
-      '[ThresholdControl] value vs threshold',
-      { value: numericValue, threshold, isActive }
-    );
     if (isActive) {
       toast({
         variant: 'destructive',
@@ -38,43 +36,93 @@ function ThresholdControl({ control, parameter }: { control: Control; parameter:
   }, [isActive, numericValue, parameter.name, parameter.unit, threshold, toast]);
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-2">
+    <div className="space-y-2 rounded-lg border p-4">
+      <div className="flex items-center justify-between gap-2">
         <Label htmlFor={`control-${control.id}`}>{control.label || 'Threshold'}</Label>
         <Button id={`control-${control.id}`} variant={isActive ? 'destructive' : 'secondary'}>
           {isActive ? 'Active' : 'Inactive'}
         </Button>
       </div>
+      <p className="text-sm text-muted-foreground">
+        {typeof numericValue === 'number'
+          ? `Current value: ${numericValue.toFixed(1)} ${parameter.unit ?? ''}`
+          : 'Waiting for data...'}
+      </p>
+      {typeof threshold === 'number' && (
+        <p className="text-xs text-muted-foreground">Threshold: {threshold}</p>
+      )}
+    </div>
+  );
+}
+
+function ToggleControl({ control }: { control: Control }) {
+  const [isEnabled, setIsEnabled] = useState(control.defaultState ?? false);
+  const { toast } = useToast();
+
+  const handleChange = (checked: boolean) => {
+    setIsEnabled(checked);
+    toast({
+      title: control.label || 'Toggle',
+      description: `Switched ${checked ? 'on' : 'off'}.`,
+    });
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+      <div className="space-y-1">
+        <Label htmlFor={`control-${control.id}`}>{control.label || 'Toggle'}</Label>
+        <p className="text-sm text-muted-foreground">{isEnabled ? 'Enabled' : 'Disabled'}</p>
+      </div>
+      <Switch id={`control-${control.id}`} checked={isEnabled} onCheckedChange={handleChange} />
+    </div>
+  );
+}
+
+function RefreshControl({ control }: { control: Control }) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+      <div className="space-y-1">
+        <p className="font-medium">{control.label || 'Refresh'}</p>
+        <p className="text-sm text-muted-foreground">Trigger a manual refresh.</p>
+      </div>
+      <Button variant="secondary">{control.label || 'Refresh'}</Button>
     </div>
   );
 }
 
 export function DashboardControls({ controls, parameters }: DashboardControlsProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
   if (!controls.length) return null;
 
   return (
-    <Card className="mb-6">
-      <CardHeader>
-        <CardTitle>Control Panel</CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-wrap items-center gap-4">
-        {controls.map((control) => {
-          switch (control.type) {
-            case 'refresh':
-              return (
-                <Button key={control.id} variant="secondary">
-                  {control.label || 'Refresh'}
-                </Button>
-              );
-            case 'threshold':
-              const parameter = parameters.find((p) => p.id === control.parameterId);
-              if (!parameter) return null;
-              return <ThresholdControl key={control.id} control={control} parameter={parameter} />;
-            default:
-              return null;
-          }
-        })}
-      </CardContent>
-    </Card>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">Control Panel</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Control Panel</DialogTitle>
+          <DialogDescription>Interact with dashboard controls.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          {controls.map((control) => {
+            switch (control.type) {
+              case 'refresh':
+                return <RefreshControl key={control.id} control={control} />;
+              case 'threshold': {
+                const parameter = parameters.find((p) => p.id === control.parameterId);
+                if (!parameter) return null;
+                return <ThresholdControl key={control.id} control={control} parameter={parameter} />;
+              }
+              case 'toggle':
+                return <ToggleControl key={control.id} control={control} />;
+              default:
+                return null;
+            }
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,10 +13,11 @@ export type Parameter = z.infer<typeof ParameterSchema>;
 
 export const ControlSchema = z.object({
   id: z.string().default(() => crypto.randomUUID()),
-  type: z.enum(['refresh', 'threshold']).default('refresh'),
+  type: z.enum(['refresh', 'threshold', 'toggle']).default('refresh'),
   label: z.string().optional(),
   parameterId: z.string().optional(),
   threshold: z.coerce.number().optional(),
+  defaultState: z.boolean().optional(),
 });
 
 export type Control = z.infer<typeof ControlSchema>;


### PR DESCRIPTION
## Summary
- add a toggle switch control type with configurable default state
- surface dashboard controls from a dialog-based control panel trigger
- refresh dashboard layout so the control button sits alongside the switch dashboard action

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c9330f27808325a4a7f5257bdbbe7c