### PR TITLE
Add secure password handling and reset workflow

### DIFF
--- a/src/actions/password-reset.ts
+++ b/src/actions/password-reset.ts
@@ -1,0 +1,143 @@
+'use server';
+
+import { randomBytes, createHash } from 'crypto';
+import { z } from 'zod';
+import { Collection } from 'mongodb';
+import { revalidatePath } from 'next/cache';
+import { getCollection, isMongoConfigured } from '@/lib/mongodb';
+import { PasswordResetToken, User, UserSchema } from '@/lib/types';
+import { hashPassword } from '@/lib/password';
+import { sendPasswordResetEmail } from '@/lib/email';
+
+const RequestPasswordResetSchema = z.object({
+  email: z.string().email('A valid email is required.'),
+});
+
+const ResetPasswordSchema = z.object({
+  token: z.string().min(1, 'Reset token is required.'),
+  password: UserSchema.shape.password,
+});
+
+async function getTokenCollection(): Promise<Collection<PasswordResetToken> | null> {
+  return getCollection<PasswordResetToken>('password_reset_tokens');
+}
+
+function buildResetUrl(token: string) {
+  const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:9002';
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  return `${normalizedBase}/login/reset/${token}`;
+}
+
+export async function requestPasswordReset(values: z.infer<typeof RequestPasswordResetSchema>) {
+  const validation = RequestPasswordResetSchema.safeParse(values);
+  if (!validation.success) {
+    return { success: false, error: 'Please provide a valid email address.' };
+  }
+
+  if (!isMongoConfigured()) {
+    return { success: false, error: 'Password resets are unavailable because the database is not configured.' };
+  }
+
+  const usersCollection = await getCollection<User>('users');
+  const tokensCollection = await getTokenCollection();
+
+  if (!usersCollection || !tokensCollection) {
+    return { success: false, error: 'Unable to connect to the database. Please try again later.' };
+  }
+
+  const email = validation.data.email.toLowerCase();
+  const user = await usersCollection.findOne({ email });
+
+  if (!user) {
+    // Return a generic success message to avoid account enumeration.
+    return {
+      success: true,
+      message: 'If an account exists for that email address, a reset link will arrive shortly.',
+    };
+  }
+
+  const token = randomBytes(32).toString('hex');
+  const tokenHash = createHash('sha256').update(token).digest('hex');
+  const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+  await tokensCollection.updateOne(
+    { username: user.username },
+    {
+      $set: {
+        username: user.username,
+        tokenHash,
+        expiresAt,
+      },
+    },
+    { upsert: true },
+  );
+
+  const resetUrl = buildResetUrl(token);
+
+  try {
+    await sendPasswordResetEmail({
+      email: user.email,
+      username: user.username,
+      resetUrl,
+    });
+  } catch (error) {
+    console.error('Failed to send password reset email:', error);
+    return { success: false, error: 'Failed to send the password reset email. Please try again later.' };
+  }
+
+  return {
+    success: true,
+    message: 'If an account exists for that email address, a reset link will arrive shortly.',
+  };
+}
+
+export async function resetPassword(values: z.infer<typeof ResetPasswordSchema>) {
+  const validation = ResetPasswordSchema.safeParse(values);
+  if (!validation.success) {
+    return { success: false, error: 'Invalid reset request.' };
+  }
+
+  if (!isMongoConfigured()) {
+    return { success: false, error: 'Password resets are unavailable because the database is not configured.' };
+  }
+
+  const usersCollection = await getCollection<User>('users');
+  const tokensCollection = await getTokenCollection();
+
+  if (!usersCollection || !tokensCollection) {
+    return { success: false, error: 'Unable to connect to the database. Please try again later.' };
+  }
+
+  const tokenHash = createHash('sha256').update(validation.data.token).digest('hex');
+  const tokenRecord = await tokensCollection.findOne({ tokenHash });
+
+  if (!tokenRecord) {
+    return { success: false, error: 'This reset link is invalid or has already been used.' };
+  }
+
+  const expiresAt = tokenRecord.expiresAt instanceof Date
+    ? tokenRecord.expiresAt
+    : new Date(tokenRecord.expiresAt);
+
+  if (expiresAt.getTime() < Date.now()) {
+    await tokensCollection.deleteOne({ username: tokenRecord.username });
+    return { success: false, error: 'This reset link has expired. Please request a new one.' };
+  }
+
+  const hashedPassword = await hashPassword(validation.data.password);
+
+  const updateResult = await usersCollection.updateOne(
+    { username: tokenRecord.username },
+    { $set: { password: hashedPassword } },
+  );
+
+  if (updateResult.matchedCount === 0) {
+    await tokensCollection.deleteOne({ username: tokenRecord.username });
+    return { success: false, error: 'Unable to update the password for this account.' };
+  }
+
+  await tokensCollection.deleteOne({ username: tokenRecord.username });
+  revalidatePath('/', 'layout');
+
+  return { success: true };
+}

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -21,8 +21,10 @@ import { useToast } from '@/hooks/use-toast';
 import { Users, Trash2, Loader2, Pencil } from 'lucide-react';
 import { User } from '@/lib/types';
 
+type ManagedUser = Omit<User, 'password'>;
+
 export default function AccountsHubPage() {
-  const [users, setUsers] = useState<User[]>([]);
+  const [users, setUsers] = useState<ManagedUser[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isDeleting, startDeleteTransition] = useTransition();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -101,6 +103,7 @@ export default function AccountsHubPage() {
                         <Users className="h-5 w-5 text-primary" />
                         <div>
                             <p className="font-medium">{user.username}</p>
+                            <p className="text-sm text-muted-foreground">{user.email}</p>
                             <p className="text-sm text-muted-foreground">
                               Dashboards: {user.dashboardNames?.join(", ") ?? "N/A"}
                             </p>

--- a/src/app/login/forgot-password/page.tsx
+++ b/src/app/login/forgot-password/page.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { ForgotPasswordForm } from '@/components/auth/forgot-password-form';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="container flex min-h-screen items-center justify-center py-10">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center space-y-2">
+          <CardTitle>Reset your password</CardTitle>
+          <CardDescription>
+            Enter the email address associated with your account and we&apos;ll send you a reset link.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <ForgotPasswordForm />
+          <Button variant="ghost" asChild className="w-full">
+            <Link href="/login">Back to login</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/login/reset/[token]/page.tsx
+++ b/src/app/login/reset/[token]/page.tsx
@@ -1,0 +1,31 @@
+import { ResetPasswordForm } from '@/components/auth/reset-password-form';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+interface ResetPasswordPageProps {
+  params: Promise<{ token: string }>;
+}
+
+export default async function ResetPasswordPage({ params }: ResetPasswordPageProps) {
+  const { token } = await params;
+
+  return (
+    <div className="container flex min-h-screen items-center justify-center py-10">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center space-y-2">
+          <CardTitle>Create a new password</CardTitle>
+          <CardDescription>
+            Choose a new password to secure your Smart Monitoring account.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <ResetPasswordForm token={token} />
+          <Button variant="ghost" asChild className="w-full">
+            <Link href="/login">Return to login</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/accounts/account-form.tsx
+++ b/src/components/accounts/account-form.tsx
@@ -16,7 +16,7 @@ import { useRouter } from 'next/navigation';
 
 type AccountFormProps = {
   dashboardNames: string[];
-  initialUser?: User;
+  initialUser?: Omit<User, 'password'>;
   isCreating: boolean;
 };
 
@@ -28,12 +28,19 @@ export function AccountForm({ dashboardNames, initialUser, isCreating }: Account
   const form = useForm<User>({
     resolver: zodResolver(UserSchema),
     defaultValues:
-      initialUser || {
-        username: '',
-        password: '',
-        dashboardNames: [],
-        role: 'user',
-      },
+      initialUser
+        ? {
+            ...initialUser,
+            email: initialUser.email,
+            password: '',
+          }
+        : {
+            username: '',
+            email: '',
+            password: '',
+            dashboardNames: [],
+            role: 'user',
+          },
   });
 
   const onSubmit = (data: User) => {
@@ -72,6 +79,20 @@ export function AccountForm({ dashboardNames, initialUser, isCreating }: Account
               <FormControl>
                 <Input placeholder="e.g., new.user" {...field} />
               </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="name@example.com" {...field} />
+              </FormControl>
+              <FormDescription>Used for password recovery and notifications.</FormDescription>
               <FormMessage />
             </FormItem>
           )}

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { requestPasswordReset } from '@/actions/password-reset';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2 } from 'lucide-react';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form';
+
+const ForgotPasswordSchema = z.object({
+  email: z.string().email({ message: 'Please enter a valid email address.' }),
+});
+
+type ForgotPasswordFormValues = z.infer<typeof ForgotPasswordSchema>;
+
+export function ForgotPasswordForm() {
+  const { toast } = useToast();
+  const [hasRequested, setHasRequested] = useState(false);
+  const [isRequesting, startTransition] = useTransition();
+
+  const form = useForm<ForgotPasswordFormValues>({
+    resolver: zodResolver(ForgotPasswordSchema),
+    defaultValues: {
+      email: '',
+    },
+  });
+
+  const onSubmit = (values: ForgotPasswordFormValues) => {
+    startTransition(async () => {
+      const result = await requestPasswordReset(values);
+
+      if (result.success) {
+        setHasRequested(true);
+        toast({
+          title: 'Check your email',
+          description: result.message ?? 'If an account exists for that email, you will receive a password reset link shortly.',
+        });
+      } else {
+        toast({
+          variant: 'destructive',
+          title: 'Request failed',
+          description: result.error ?? 'Unable to request a password reset. Please try again.',
+        });
+      }
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="name@example.com" autoComplete="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full" disabled={isRequesting || hasRequested}>
+          {isRequesting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          {hasRequested ? 'Email sent' : 'Send reset link'}
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -11,6 +11,7 @@ import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 import { Loader2 } from 'lucide-react';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form';
+import Link from 'next/link';
 
 const LoginSchema = z.object({
   username: z.string().min(1, { message: 'Username is required.' }),
@@ -61,7 +62,7 @@ export function LoginForm() {
             <FormItem>
               <FormLabel>Username</FormLabel>
               <FormControl>
-                <Input placeholder="Enter your username" {...field} />
+                <Input placeholder="Enter your username" autoComplete="username" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -74,7 +75,7 @@ export function LoginForm() {
             <FormItem>
               <FormLabel>Password</FormLabel>
               <FormControl>
-                <Input type="password" placeholder="••••••••" {...field} />
+                <Input type="password" placeholder="••••••••" autoComplete="current-password" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -84,6 +85,11 @@ export function LoginForm() {
           {isLoggingIn ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
           Log In
         </Button>
+        <div className="text-center text-sm">
+          <Link href="/login/forgot-password" className="text-primary underline-offset-4 hover:underline">
+            Forgot your password?
+          </Link>
+        </div>
       </form>
     </Form>
   );

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { resetPassword } from '@/actions/password-reset';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form';
+
+const ResetPasswordSchema = z
+  .object({
+    password: z.string().min(6, { message: 'Password must be at least 6 characters.' }),
+    confirmPassword: z.string().min(6, { message: 'Confirm password must be at least 6 characters.' }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Passwords do not match.',
+    path: ['confirmPassword'],
+  });
+
+type ResetPasswordFormValues = z.infer<typeof ResetPasswordSchema>;
+
+type ResetPasswordFormProps = {
+  token: string;
+};
+
+export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
+  const { toast } = useToast();
+  const router = useRouter();
+  const [isResetting, startTransition] = useTransition();
+
+  const form = useForm<ResetPasswordFormValues>({
+    resolver: zodResolver(ResetPasswordSchema),
+    defaultValues: {
+      password: '',
+      confirmPassword: '',
+    },
+  });
+
+  const onSubmit = (values: ResetPasswordFormValues) => {
+    startTransition(async () => {
+      const result = await resetPassword({ token, password: values.password });
+
+      if (result.success) {
+        toast({
+          title: 'Password updated',
+          description: 'Your password has been reset. You can now log in with the new password.',
+        });
+        router.push('/login');
+        router.refresh();
+      } else {
+        toast({
+          variant: 'destructive',
+          title: 'Reset failed',
+          description: result.error ?? 'Unable to reset your password. Please request a new link.',
+        });
+      }
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>New Password</FormLabel>
+              <FormControl>
+                <Input type="password" placeholder="••••••••" autoComplete="new-password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="confirmPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Confirm Password</FormLabel>
+              <FormControl>
+                <Input type="password" placeholder="••••••••" autoComplete="new-password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full" disabled={isResetting}>
+          {isResetting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          Reset Password
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,48 @@
+type PasswordResetEmailParams = {
+  email: string;
+  username: string;
+  resetUrl: string;
+};
+
+export function isEmailConfigured() {
+  return Boolean(process.env.RESEND_API_KEY);
+}
+
+export async function sendPasswordResetEmail({ email, username, resetUrl }: PasswordResetEmailParams) {
+  const apiKey = process.env.RESEND_API_KEY;
+
+  if (!apiKey) {
+    console.info('RESEND_API_KEY is not configured. Password reset link:', resetUrl);
+    return;
+  }
+
+  const fromAddress = process.env.RESEND_FROM_EMAIL || 'no-reply@smart-monitoring.local';
+
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: fromAddress,
+      to: email,
+      subject: 'Reset your Smart Monitoring password',
+      html: [
+        `<p>Hi ${username},</p>`,
+        '<p>You recently requested to reset your Smart Monitoring password.</p>',
+        '<p>Click the button below to set a new password. This link will expire in 1 hour.</p>',
+        `<p><a href="${resetUrl}" style="display:inline-block;padding:12px 20px;background:#2563eb;color:#ffffff;text-decoration:none;border-radius:6px">Reset password</a></p>`,
+        `<p>If the button does not work, copy and paste this URL into your browser:</p>`,
+        `<p><a href="${resetUrl}">${resetUrl}</a></p>`,
+        '<p>If you did not request a password reset, you can safely ignore this email.</p>',
+        '<p>— Smart Monitoring Team</p>',
+      ].join(''),
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Failed to send password reset email: ${response.status} ${errorBody}`);
+  }
+}

--- a/src/lib/password.ts
+++ b/src/lib/password.ts
@@ -1,0 +1,35 @@
+import { randomBytes, scrypt as scryptCallback, timingSafeEqual } from 'crypto';
+import { promisify } from 'util';
+
+const scrypt = promisify(scryptCallback);
+const SALT_LENGTH = 16;
+const KEY_LENGTH = 64;
+
+function bufferEqual(a: Buffer, b: Buffer): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(SALT_LENGTH).toString('hex');
+  const derivedKey = (await scrypt(password, salt, KEY_LENGTH)) as Buffer;
+  return `${salt}:${derivedKey.toString('hex')}`;
+}
+
+export async function verifyPassword(password: string, hashed: string): Promise<boolean> {
+  const [salt, storedKeyHex] = hashed.split(':');
+  if (!salt || !storedKeyHex) {
+    return false;
+  }
+
+  try {
+    const derivedKey = (await scrypt(password, salt, KEY_LENGTH)) as Buffer;
+    const storedKey = Buffer.from(storedKeyHex, 'hex');
+    return bufferEqual(derivedKey, storedKey);
+  } catch (error) {
+    console.error('Password verification failed:', error);
+    return false;
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,9 +32,18 @@ export type Config = z.infer<typeof ConfigSchema>;
 
 export const UserSchema = z.object({
   username: z.string().min(1, 'Username is required.'),
+  email: z.string().email('A valid email is required.'),
   password: z.string().min(6, 'Password must be at least 6 characters.'),
   dashboardNames: z.array(z.string()),
   role: z.enum(['admin', 'user']).default('user'),
 });
 
 export type User = z.infer<typeof UserSchema>;
+
+export const PasswordResetTokenSchema = z.object({
+  username: z.string().min(1, 'Username is required.'),
+  tokenHash: z.string().min(1, 'Token hash is required.'),
+  expiresAt: z.date(),
+});
+
+export type PasswordResetToken = z.infer<typeof PasswordResetTokenSchema>;


### PR DESCRIPTION
## Summary
- hash and verify user passwords with Node scrypt utilities and require unique email addresses for accounts
- add password reset server actions with token storage and Resend-powered email notifications
- build forgot/reset password pages and forms, update login and account management UIs to capture email addresses and surface reset links

## Testing
- npm run lint *(fails: existing lint errors around no-explicit-any and unused values)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cbd276f57483259845c61f0ab200ec