### PR TITLE
Update branding to Nay Project and add footer handle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,12 +2,13 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { cn } from '@/lib/utils';
 import { AppHeader } from '@/components/common/header';
-import { Toaster } from "@/components/ui/toaster";
+import { Toaster } from '@/components/ui/toaster';
 import { getSession } from '@/actions/session';
 import { isMongoConfigured } from '@/lib/mongodb';
+import { APP_NAME, APP_SOCIAL_HANDLE } from '@/lib/branding';
 
 export const metadata: Metadata = {
-  title: 'Smart Monitoring',
+  title: APP_NAME,
   description: 'Configure and display your parameters dynamically.',
 };
 
@@ -27,11 +28,14 @@ export default async function RootLayout({
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
       </head>
       <body className={cn('min-h-screen bg-background font-body antialiased')}>
-            <div className="relative flex min-h-screen flex-col">
-                {(session.isLoggedIn || !isDbConnected) && <AppHeader session={session} />}
-                <main className="flex-1">{children}</main>
-            </div>
-            <Toaster />
+        <div className="relative flex min-h-screen flex-col">
+          {(session.isLoggedIn || !isDbConnected) && <AppHeader session={session} />}
+          <main className="flex-1">{children}</main>
+          <footer className="border-t border-border/40 bg-background/80 py-4 text-center text-xs text-muted-foreground">
+            {APP_SOCIAL_HANDLE}
+          </footer>
+        </div>
+        <Toaster />
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,12 +1,13 @@
 import { LoginForm } from '@/components/auth/login-form';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { APP_NAME } from '@/lib/branding';
 
 export default function LoginPage() {
   return (
     <div className="container flex min-h-screen items-center justify-center py-10">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
-          <CardTitle>Smart Monitoring</CardTitle>
+          <CardTitle>{APP_NAME}</CardTitle>
           <CardDescription>Welcome back. Please log in to continue.</CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/app/login/reset/[token]/page.tsx
+++ b/src/app/login/reset/[token]/page.tsx
@@ -2,6 +2,7 @@ import { ResetPasswordForm } from '@/components/auth/reset-password-form';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import { APP_NAME } from '@/lib/branding';
 
 interface ResetPasswordPageProps {
   params: Promise<{ token: string }>;
@@ -16,7 +17,7 @@ export default async function ResetPasswordPage({ params }: ResetPasswordPagePro
         <CardHeader className="text-center space-y-2">
           <CardTitle>Create a new password</CardTitle>
           <CardDescription>
-            Choose a new password to secure your Smart Monitoring account.
+            Choose a new password to secure your {APP_NAME} account.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { getSession } from '@/actions/session';
 import { GetStartedDialog } from '@/components/landing/get-started-dialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { APP_NAME } from '@/lib/branding';
 import {
   Activity,
   AlarmCheck,
@@ -50,8 +51,7 @@ const assurances = [
   },
   {
     title: 'Built for operations',
-    description:
-      'From factory floors to remote field deployments, Smart Monitoring adapts to the environments you rely on.',
+    description: `From factory floors to remote field deployments, ${APP_NAME} adapts to the environments you rely on.`,
     icon: Lock,
   },
 ];
@@ -81,13 +81,13 @@ function LandingContent() {
       <div className="mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-6xl flex-col items-center px-6 pb-20 pt-24 sm:px-10 lg:px-12">
         <div className="text-center">
           <span className="inline-flex items-center rounded-full bg-white/10 px-4 py-1 text-sm font-medium backdrop-blur">
-            Smart Monitoring Platform
+            {APP_NAME} Platform
           </span>
           <h1 className="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl md:text-6xl">
             Know what is happening across your operations in real time.
           </h1>
           <p className="mx-auto mt-6 max-w-3xl text-lg text-slate-200/80">
-            Smart Monitoring centralizes telemetry, alerting, and automation so that every member of your team can make faster, safer
+            {APP_NAME} centralizes telemetry, alerting, and automation so that every member of your team can make faster, safer
             decisions. Visualize critical metrics, trigger workflows, and deliver reliable service without juggling multiple tools.
           </p>
           <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
@@ -120,7 +120,7 @@ function LandingContent() {
         </div>
 
         <div className="mt-20 w-full rounded-2xl border border-white/10 bg-white/5 p-8 sm:p-10">
-          <h2 className="text-2xl font-semibold text-white sm:text-3xl">Why teams choose Smart Monitoring</h2>
+          <h2 className="text-2xl font-semibold text-white sm:text-3xl">Why teams choose {APP_NAME}</h2>
           <p className="mt-3 max-w-3xl text-base text-slate-200/80">
             Every deployment is unique. We partner with you to understand your goals, tailor dashboards, and roll out automation that
             matches your environment. Share a few details about your project to begin the conversation.

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -8,6 +8,7 @@ import { PanelsTopLeft } from 'lucide-react';
 import { LocationTime } from './location-time';
 import { UserNav } from './user-nav';
 import { SessionData } from '@/lib/session';
+import { APP_NAME } from '@/lib/branding';
 
 interface AppHeaderProps {
   session: SessionData;
@@ -37,7 +38,7 @@ export function AppHeader({ session }: AppHeaderProps) {
         <div className="mr-6 flex items-center">
           <Link href="/" className="flex items-center space-x-2">
             <PanelsTopLeft className="h-6 w-6 text-primary" />
-            <span className="font-bold">Smart Monitoring</span>
+            <span className="font-bold">{APP_NAME}</span>
           </Link>
         </div>
         <nav className="flex flex-1 items-center space-x-6 text-sm font-medium">
@@ -55,8 +56,8 @@ export function AppHeader({ session }: AppHeaderProps) {
           ))}
         </nav>
         <div className="flex items-center gap-4">
-            <LocationTime />
-            <UserNav />
+          <LocationTime />
+          <UserNav />
         </div>
       </div>
     </header>

--- a/src/components/landing/get-started-dialog.tsx
+++ b/src/components/landing/get-started-dialog.tsx
@@ -20,6 +20,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
+import { APP_NAME } from '@/lib/branding';
 
 const InquiryFormSchema = z.object({
   fullName: z.string().min(2, { message: 'Please enter your full name.' }),
@@ -58,7 +59,7 @@ export function GetStartedDialog({ triggerClassName }: GetStartedDialogProps) {
 
     try {
       const contactEmail = process.env.NEXT_PUBLIC_CONTACT_EMAIL ?? 'touati.hakam.youssef@gmail.com';
-      const subject = encodeURIComponent('Smart Monitoring Project Inquiry');
+      const subject = encodeURIComponent(`${APP_NAME} Project Inquiry`);
       const body = encodeURIComponent(
         [
           `Full Name: ${values.fullName}`,

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -1,0 +1,3 @@
+export const APP_NAME = 'Nay Project';
+export const APP_SOCIAL_HANDLE = '@smart_monitoring';
+

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,3 +1,5 @@
+import { APP_NAME } from '@/lib/branding';
+
 type PasswordResetEmailParams = {
   email: string;
   username: string;
@@ -16,7 +18,7 @@ export async function sendPasswordResetEmail({ email, username, resetUrl }: Pass
     return;
   }
 
-  const fromAddress = process.env.RESEND_FROM_EMAIL || 'no-reply@smart-monitoring.local';
+  const fromAddress = process.env.RESEND_FROM_EMAIL || 'no-reply@nay-project.local';
 
   const response = await fetch('https://api.resend.com/emails', {
     method: 'POST',
@@ -27,16 +29,16 @@ export async function sendPasswordResetEmail({ email, username, resetUrl }: Pass
     body: JSON.stringify({
       from: fromAddress,
       to: email,
-      subject: 'Reset your Smart Monitoring password',
+      subject: `Reset your ${APP_NAME} password`,
       html: [
         `<p>Hi ${username},</p>`,
-        '<p>You recently requested to reset your Smart Monitoring password.</p>',
+        `<p>You recently requested to reset your ${APP_NAME} password.</p>`,
         '<p>Click the button below to set a new password. This link will expire in 1 hour.</p>',
         `<p><a href="${resetUrl}" style="display:inline-block;padding:12px 20px;background:#2563eb;color:#ffffff;text-decoration:none;border-radius:6px">Reset password</a></p>`,
         `<p>If the button does not work, copy and paste this URL into your browser:</p>`,
         `<p><a href="${resetUrl}">${resetUrl}</a></p>`,
         '<p>If you did not request a password reset, you can safely ignore this email.</p>',
-        '<p>— Smart Monitoring Team</p>',
+        `<p>— ${APP_NAME} Team</p>`,
       ].join(''),
     }),
   });


### PR DESCRIPTION
## Summary
- centralize the project branding in a shared module and replace the Smart Monitoring label with Nay Project across the UI
- update authentication pages, landing content, and email templates to use the new brand name
- add a global footer that surfaces the @smart_monitoring handle

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdadf441c8325a6a3c028f10762e5