### PR TITLE
Add MongoDB-backed parameter streaming and controls

### DIFF
--- a/src/actions/data.ts
+++ b/src/actions/data.ts
@@ -1,97 +1,28 @@
 'use server';
 
-import { Parameter } from "@/lib/types";
+import { maybeSimulateParameter } from '@/lib/parameter-data';
+import type { Parameter } from '@/lib/types';
 
-// This is a map to store the "current" server-side value for each parameter.
-// In a real application, this would be replaced by a database or a real-time data source.
-const parameterDataStore = new Map<string, any>();
-
-function initializeParameterData(parameterId: string, displayType: Parameter['displayType']) {
-    switch (displayType) {
-        case 'line':
-        case 'bar':
-            // For charts, initialize with an array of data points
-            parameterDataStore.set(parameterId, 
-                Array.from({ length: 10 }, (_, i) => ({
-                    name: `Point ${i + 1}`,
-                    value: Math.random() * 80 + 10,
-                }))
-            );
-            break;
-        case 'stat':
-            // For stats, initialize with a value and a previous value
-            const initialValue = Math.random() * 80 + 10;
-            parameterDataStore.set(parameterId, {
-                value: initialValue,
-                previousValue: initialValue,
-            });
-            break;
-        default:
-            // For gauges, progress bars, etc.
-             parameterDataStore.set(parameterId, Math.random() * 100);
-    }
-}
-
-function getNextData(parameter: Parameter) {
-    const { id, displayType } = parameter;
-
-    if (!parameterDataStore.has(id)) {
-        initializeParameterData(id, displayType);
-    }
-
-    const currentValue = parameterDataStore.get(id);
-
-    switch (displayType) {
-        case 'line':
-        case 'bar':
-            const newDataSet = [...currentValue];
-            const lastValue = newDataSet[newDataSet.length - 1]?.value || 50;
-            const change = (Math.random() - 0.5) * 5;
-            let newValue = lastValue + change;
-            if (newValue < 0) newValue = 0;
-            if (newValue > 100) newValue = 100;
-            const newDataPoint = { time: (newDataSet[newDataSet.length - 1]?.time || 0) + 1, value: newValue };
-            
-            newDataSet.push(newDataPoint);
-            if (newDataSet.length > 20) {
-              newDataSet.shift();
-            }
-            parameterDataStore.set(id, newDataSet);
-            break;
-        case 'stat':
-             const changeStat = (Math.random() - 0.5) * 10;
-             let newStatValue = currentValue.value + changeStat;
-             if (newStatValue < 0) newStatValue = 0;
-             if (newStatValue > 100) newStatValue = 100;
-             parameterDataStore.set(id, { value: newStatValue, previousValue: currentValue.value });
-            break;
-        default:
-             const changeDefault = (Math.random() - 0.5) * 10;
-             let newDefaultValue = currentValue + changeDefault;
-             if (newDefaultValue < 0) newDefaultValue = 0;
-             if (newDefaultValue > 100) newDefaultValue = 100;
-             parameterDataStore.set(id, newDefaultValue);
-    }
-    
-    return parameterDataStore.get(id);
-}
-
+type ParameterDescriptor = Pick<Parameter, 'id' | 'displayType'>;
 
 /**
- * Fetches the latest data for a given parameter.
- * This is a server action that simulates fetching data from a backend service.
- * @param parameter The parameter to fetch data for.
- * @returns The latest data for the parameter.
+ * Fetches the latest data for a given parameter on the specified dashboard.
+ * When MongoDB is configured, the value is persisted so multiple clients and
+ * subsequent sessions see the same readings. In development, values are
+ * simulated to provide live updates.
  */
-export async function getLatestParameterData(parameter: Parameter): Promise<any> {
-    try {
-        // In a real-world scenario, you would fetch data from a database, an IoT device, or an external API.
-        // For this demo, we'll generate a new "random" value based on the previous one to simulate real-time changes.
-        const data = getNextData(parameter);
-        return data;
-    } catch (error) {
-        console.error(`Failed to fetch data for parameter ${parameter.id}:`, error);
-        // In a real app, you might want to return a specific error object.
-        return null;
-    }
+export async function getLatestParameterData(
+  dashboardName: string,
+  parameter: ParameterDescriptor,
+): Promise<unknown> {
+  try {
+    const payload = await maybeSimulateParameter(dashboardName, {
+      id: parameter.id,
+      displayType: parameter.displayType,
+    });
+    return payload;
+  } catch (error) {
+    console.error(`Failed to fetch data for parameter ${parameter.id}:`, error);
+    return null;
+  }
 }

--- a/src/app/api/dashboards/[dashboard]/parameters/[parameterId]/route.ts
+++ b/src/app/api/dashboards/[dashboard]/parameters/[parameterId]/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getParameterData, recordParameterValue } from '@/lib/parameter-data';
+import type { Parameter } from '@/lib/types';
+
+type RouteParams = { dashboard: string; parameterId: string };
+
+type HandlerContext = { params: Promise<RouteParams> };
+
+function decodeParam(value: string): string {
+  return decodeURIComponent(value);
+}
+
+function parseDisplayType(raw: string | null): Parameter['displayType'] | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  return raw as Parameter['displayType'];
+}
+
+export async function GET(request: NextRequest, context: HandlerContext) {
+  const { dashboard, parameterId } = await context.params;
+  const dashboardName = decodeParam(dashboard);
+  const id = decodeParam(parameterId);
+  const url = new URL(request.url);
+  const displayType = parseDisplayType(url.searchParams.get('displayType'));
+
+  try {
+    const data = await getParameterData(
+      dashboardName,
+      { id, displayType },
+      { initialize: !!displayType },
+    );
+
+    if (data === null) {
+      return NextResponse.json({ error: 'Parameter not found.' }, { status: 404 });
+    }
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    console.error(`Failed to load parameter ${id} for ${dashboardName}:`, error);
+    return NextResponse.json({ error: 'Unable to load parameter data.' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest, context: HandlerContext) {
+  const { dashboard, parameterId } = await context.params;
+  const dashboardName = decodeParam(dashboard);
+  const id = decodeParam(parameterId);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload.' }, { status: 400 });
+  }
+
+  const payload = typeof body === 'object' && body !== null ? (body as Record<string, unknown>) : {};
+
+  const value = typeof payload.value === 'number' ? payload.value : Number(payload.value);
+  if (!Number.isFinite(value)) {
+    return NextResponse.json({ error: 'A numeric "value" field is required.' }, { status: 400 });
+  }
+
+  const displayType = parseDisplayType(
+    (typeof payload.displayType === 'string' ? payload.displayType : null) ?? null,
+  );
+  const timestampValue = payload.timestamp;
+  let timestamp: Date | undefined;
+
+  if (timestampValue !== undefined) {
+    const candidate =
+      timestampValue instanceof Date
+        ? timestampValue
+        : typeof timestampValue === 'string' || typeof timestampValue === 'number'
+          ? new Date(timestampValue)
+          : null;
+
+    if (!candidate || Number.isNaN(candidate.getTime())) {
+      return NextResponse.json({ error: 'Invalid timestamp.' }, { status: 400 });
+    }
+
+    timestamp = candidate;
+  }
+
+  try {
+    const data = await recordParameterValue(
+      dashboardName,
+      { id, displayType },
+      value,
+      timestamp,
+    );
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : 'Unable to update parameter value.';
+    console.error(`Failed to update parameter ${id} for ${dashboardName}:`, error);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/dashboards/[dashboard]/parameters/[parameterId]/stream/route.ts
+++ b/src/app/api/dashboards/[dashboard]/parameters/[parameterId]/stream/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest } from 'next/server';
+
+import { getParameterData, maybeSimulateParameter } from '@/lib/parameter-data';
+import type { Parameter } from '@/lib/types';
+import { subscribeToParameter } from '@/lib/realtime';
+
+const encoder = new TextEncoder();
+const STREAM_SIMULATION_INTERVAL_MS = Number(process.env.PARAMETER_STREAM_SIMULATION_INTERVAL_MS ?? '2500');
+const SIMULATION_ENABLED = process.env.PARAMETER_DATA_SIMULATION !== 'off';
+
+type RouteParams = { dashboard: string; parameterId: string };
+
+type HandlerContext = { params: Promise<RouteParams> };
+
+function decodeParam(value: string): string {
+  return decodeURIComponent(value);
+}
+
+function parseDisplayType(raw: string | null): Parameter['displayType'] | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  return raw as Parameter['displayType'];
+}
+
+function pushEvent(controller: ReadableStreamDefaultController<Uint8Array>, payload: unknown) {
+  const data = JSON.stringify({ data: payload });
+  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+}
+
+export async function GET(request: NextRequest, context: HandlerContext) {
+  const { dashboard, parameterId } = await context.params;
+  const dashboardName = decodeParam(dashboard);
+  const id = decodeParam(parameterId);
+  const url = new URL(request.url);
+  const displayType = parseDisplayType(url.searchParams.get('displayType'));
+
+  try {
+    const initial = await getParameterData(
+      dashboardName,
+      { id, displayType },
+      { initialize: !!displayType },
+    );
+
+    if (initial === null) {
+      return new Response('Parameter not found.', { status: 404 });
+    }
+
+    let cleanup: (() => void) | null = null;
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        pushEvent(controller, initial);
+
+        const unsubscribe = subscribeToParameter(dashboardName, id, (update) => {
+          pushEvent(controller, update.data);
+        });
+
+        let interval: ReturnType<typeof setInterval> | null = null;
+
+        if (SIMULATION_ENABLED) {
+          interval = setInterval(() => {
+            maybeSimulateParameter(dashboardName, { id, displayType }).catch((error) => {
+              console.error(
+                `Failed to advance simulated data for ${dashboardName}/${id}:`,
+                error,
+              );
+            });
+          }, STREAM_SIMULATION_INTERVAL_MS);
+        }
+
+        const keepAlive = setInterval(() => {
+          controller.enqueue(encoder.encode(':keep-alive\n\n'));
+        }, 15000);
+
+        cleanup = () => {
+          const handler = cleanup;
+          cleanup = null;
+          unsubscribe();
+          if (interval) {
+            clearInterval(interval);
+          }
+          clearInterval(keepAlive);
+          controller.close();
+          if (handler) {
+            request.signal.removeEventListener('abort', handler);
+          }
+        };
+
+        request.signal.addEventListener('abort', cleanup);
+      },
+      cancel() {
+        if (cleanup) {
+          cleanup();
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+      },
+    });
+  } catch (error) {
+    console.error(`Failed to start parameter stream for ${dashboardName}/${id}:`, error);
+    return new Response('Unable to start stream.', { status: 500 });
+  }
+}

--- a/src/app/dashboard/[name]/page.tsx
+++ b/src/app/dashboard/[name]/page.tsx
@@ -23,7 +23,10 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
   }
 
   const config = await getConfiguration(configName);
-  const controlStates = await getControlStates(config.controls.map((control) => control.id));
+  const controlStates = await getControlStates(
+    config.name,
+    config.controls.map((control) => control.id),
+  );
 
   if (config.parameters.length === 0) {
     return (
@@ -47,6 +50,7 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
         <h1 className="text-3xl font-bold">{config.name}</h1>
         <div className="flex items-center gap-2">
           <DashboardControls
+            dashboardName={config.name}
             controls={config.controls}
             parameters={config.parameters}
             controlStates={controlStates}
@@ -56,7 +60,7 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
           </Button>
         </div>
       </div>
-      <WidgetGrid parameters={config.parameters} />
+      <WidgetGrid dashboardName={config.name} parameters={config.parameters} />
     </div>
   );
 }

--- a/src/components/display/bar-chart.tsx
+++ b/src/components/display/bar-chart.tsx
@@ -8,11 +8,17 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type BarChartComponentProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function BarChartComponent({ parameter }: BarChartComponentProps) {
-  const { data, isLoading } = useParameterData(parameter, []);
+export function BarChartComponent({ dashboardName, parameter }: BarChartComponentProps) {
+  const { data, isLoading } = useParameterData<Array<{ name: string; value: number }>>(
+    dashboardName,
+    parameter,
+    [],
+  );
+  const series = data ?? [];
 
   const chartConfig = {
     value: {
@@ -28,33 +34,33 @@ export function BarChartComponent({ parameter }: BarChartComponentProps) {
       description={`Bar chart for ${parameter.name.toLowerCase()}.`}
       contentClassName="pl-0 pr-4 pb-4"
     >
-        {isLoading && data.length === 0 ? (
+      {isLoading && series.length === 0 ? (
         <div className="p-6 h-full w-full flex items-center justify-center">
-            <Skeleton className="h-full w-full" />
+          <Skeleton className="h-full w-full" />
         </div>
-        ) : (
-      <ChartContainer config={chartConfig} className="h-full w-full">
-        <RechartsBarChart
-          accessibilityLayer
-          data={data}
-          layout="horizontal"
-          margin={{ top: 5, right: 10, left: 10, bottom: 0 }}
-        >
-          <CartesianGrid vertical={false} />
-          <XAxis dataKey="name" tickLine={false} axisLine={false} tickMargin={8} tickFormatter={() => ''} />
-          <ChartTooltip
-            cursor={false}
-            content={
-              <ChartTooltipContent
-                indicator="dot"
-                formatter={(value) => `${Number(value).toFixed(1)} ${parameter.unit || ''}`}
-              />
-            }
-          />
-          <Bar dataKey="value" fill="var(--color-value)" radius={4} />
-        </RechartsBarChart>
-      </ChartContainer>
-        )}
+      ) : (
+        <ChartContainer config={chartConfig} className="h-full w-full">
+          <RechartsBarChart
+            accessibilityLayer
+            data={series}
+            layout="horizontal"
+            margin={{ top: 5, right: 10, left: 10, bottom: 0 }}
+          >
+            <CartesianGrid vertical={false} />
+            <XAxis dataKey="name" tickLine={false} axisLine={false} tickMargin={8} tickFormatter={() => ''} />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  indicator="dot"
+                  formatter={(value) => `${Number(value).toFixed(1)} ${parameter.unit || ''}`}
+                />
+              }
+            />
+            <Bar dataKey="value" fill="var(--color-value)" radius={4} />
+          </RechartsBarChart>
+        </ChartContainer>
+      )}
     </WidgetCardWrapper>
   );
 }

--- a/src/components/display/gauge-chart.tsx
+++ b/src/components/display/gauge-chart.tsx
@@ -8,25 +8,27 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type RadialGaugeProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function RadialGauge({ parameter }: RadialGaugeProps) {
-    const { data: value, isLoading } = useParameterData(parameter, 50);
+export function RadialGauge({ dashboardName, parameter }: RadialGaugeProps) {
+  const { data: rawValue, isLoading } = useParameterData<number>(dashboardName, parameter, 50);
 
-    if (isLoading) {
+  if (isLoading) {
     return (
-        <WidgetCardWrapper
+      <WidgetCardWrapper
         title={parameter.name}
         icon={parameter.icon}
         description={parameter.description}
         contentClassName="flex items-center justify-center p-4"
-        >
+      >
         <Skeleton className="aspect-square h-full w-full rounded-full" />
-        </WidgetCardWrapper>
+      </WidgetCardWrapper>
     );
-    }
+  }
 
+  const value = rawValue ?? 0;
 
   const percentage = value / 100;
   const size = 200;

--- a/src/components/display/line-chart.tsx
+++ b/src/components/display/line-chart.tsx
@@ -8,11 +8,17 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type LineChartComponentProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function LineChartComponent({ parameter }: LineChartComponentProps) {
-  const { data, isLoading } = useParameterData(parameter, []);
+export function LineChartComponent({ dashboardName, parameter }: LineChartComponentProps) {
+  const { data, isLoading } = useParameterData<Array<{ time: number; value: number }>>(
+    dashboardName,
+    parameter,
+    [],
+  );
+  const series = data ?? [];
 
   const chartConfig = {
     value: {
@@ -28,33 +34,33 @@ export function LineChartComponent({ parameter }: LineChartComponentProps) {
       description={`Live trend for ${parameter.name.toLowerCase()}.`}
       contentClassName="pl-0 pr-4 pb-4"
     >
-      {isLoading && data.length === 0 ? (
+      {isLoading && series.length === 0 ? (
         <div className="p-6 h-full w-full flex items-center justify-center">
-            <Skeleton className="h-full w-full" />
+          <Skeleton className="h-full w-full" />
         </div>
       ) : (
-      <ChartContainer config={chartConfig} className="h-full w-full">
-        <AreaChart data={data} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
-          <CartesianGrid vertical={false} />
-          <XAxis dataKey="time" tickLine={false} axisLine={false} tickMargin={8} tickFormatter={() => ''} />
-          <ChartTooltip
-            cursor={false}
-            content={
-              <ChartTooltipContent
-                indicator="dot"
-                formatter={(value) => `${Number(value).toFixed(1)} ${parameter.unit || ''}`}
-              />
-            }
-          />
-          <defs>
-            <linearGradient id="fillValue" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="var(--color-value)" stopOpacity={0.8} />
-              <stop offset="95%" stopColor="var(--color-value)" stopOpacity={0.1} />
-            </linearGradient>
-          </defs>
-          <Area dataKey="value" type="natural" fill="url(#fillValue)" stroke="var(--color-value)" stackId="a" />
-        </AreaChart>
-      </ChartContainer>
+        <ChartContainer config={chartConfig} className="h-full w-full">
+          <AreaChart data={series} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
+            <CartesianGrid vertical={false} />
+            <XAxis dataKey="time" tickLine={false} axisLine={false} tickMargin={8} tickFormatter={() => ''} />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  indicator="dot"
+                  formatter={(value) => `${Number(value).toFixed(1)} ${parameter.unit || ''}`}
+                />
+              }
+            />
+            <defs>
+              <linearGradient id="fillValue" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="var(--color-value)" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="var(--color-value)" stopOpacity={0.1} />
+              </linearGradient>
+            </defs>
+            <Area dataKey="value" type="natural" fill="url(#fillValue)" stroke="var(--color-value)" stackId="a" />
+          </AreaChart>
+        </ChartContainer>
       )}
     </WidgetCardWrapper>
   );

--- a/src/components/display/linear-gauge.tsx
+++ b/src/components/display/linear-gauge.tsx
@@ -7,11 +7,13 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type LinearGaugeProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function LinearGauge({ parameter }: LinearGaugeProps) {
-  const { data: value, isLoading } = useParameterData(parameter, 50);
+export function LinearGauge({ dashboardName, parameter }: LinearGaugeProps) {
+  const { data, isLoading } = useParameterData<number>(dashboardName, parameter, 50);
+  const value = data ?? 0;
 
   const percentage = (value / 100) * 100;
 

--- a/src/components/display/progress-bar.tsx
+++ b/src/components/display/progress-bar.tsx
@@ -7,11 +7,13 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type ProgressBarProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function ProgressBar({ parameter }: ProgressBarProps) {
-  const { data: value, isLoading } = useParameterData(parameter, 50);
+export function ProgressBar({ dashboardName, parameter }: ProgressBarProps) {
+  const { data, isLoading } = useParameterData<number>(dashboardName, parameter, 50);
+  const value = data ?? 0;
 
   return (
     <WidgetCardWrapper title={parameter.name} icon={parameter.icon} contentClassName="flex flex-col justify-center space-y-4">

--- a/src/components/display/stat-card.tsx
+++ b/src/components/display/stat-card.tsx
@@ -8,11 +8,16 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type StatCardProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function StatCard({ parameter }: StatCardProps) {
-  const { data, isLoading } = useParameterData(parameter);
+export function StatCard({ dashboardName, parameter }: StatCardProps) {
+  const { data, isLoading } = useParameterData<{ value: number; previousValue: number }>(
+    dashboardName,
+    parameter,
+    null,
+  );
 
   if (isLoading || !data) {
     return (
@@ -23,8 +28,8 @@ export function StatCard({ parameter }: StatCardProps) {
         contentClassName="flex flex-col items-center justify-center"
       >
         <div className="h-full flex flex-col items-center justify-center gap-2">
-            <Skeleton className="h-10 w-24" />
-            <Skeleton className="h-5 w-16" />
+          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-5 w-16" />
         </div>
       </WidgetCardWrapper>
     );
@@ -46,11 +51,7 @@ export function StatCard({ parameter }: StatCardProps) {
         <p className="font-bold text-4xl">
           {value.toFixed(1)}
         </p>
-        <span
-          className="ml-2 text-muted-foreground text-xl"
-        >
-          {parameter.unit}
-        </span>
+        <span className="ml-2 text-muted-foreground text-xl">{parameter.unit}</span>
       </div>
       <div
         className={cn(

--- a/src/components/display/status-light.tsx
+++ b/src/components/display/status-light.tsx
@@ -7,11 +7,13 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type StatusLightProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function StatusLight({ parameter }: StatusLightProps) {
-  const { data: value, isLoading } = useParameterData(parameter, 50);
+export function StatusLight({ dashboardName, parameter }: StatusLightProps) {
+  const { data, isLoading } = useParameterData<number>(dashboardName, parameter, 50);
+  const value = data ?? 0;
 
   const getStatus = (val: number) => {
     if (val < 33) return { label: 'OK', color: 'bg-green-500', shadow: 'shadow-[0_0_12px_4px] shadow-green-500/70' };
@@ -33,11 +35,11 @@ export function StatusLight({ parameter }: StatusLightProps) {
       {isLoading ? (
         <Skeleton className={cn('rounded-full', lightSize)} />
       ) : (
-         <div className={cn('relative', lightSize)}>
-            <div className={cn('h-full w-full rounded-full', status.color, status.shadow)} />
+        <div className={cn('relative', lightSize)}>
+          <div className={cn('h-full w-full rounded-full', status.color, status.shadow)} />
         </div>
       )}
-     
+
       <p className={cn('font-semibold', labelSize)}>{isLoading ? <Skeleton className="h-6 w-20" /> : status.label}</p>
       <p className="text-sm text-muted-foreground">
         {isLoading ? '...' : value.toFixed(1)} {parameter.unit}

--- a/src/components/display/widget-grid.tsx
+++ b/src/components/display/widget-grid.tsx
@@ -11,12 +11,14 @@ import { LinearGauge } from './linear-gauge';
 import { StatusLight } from './status-light';
 
 type WidgetGridProps = {
+  dashboardName: string;
   parameters: Parameter[];
 };
 
-export function WidgetGrid({ parameters }: WidgetGridProps) {
+export function WidgetGrid({ dashboardName, parameters }: WidgetGridProps) {
   const renderWidget = (param: Parameter) => {
     const commonProps = {
+      dashboardName,
       parameter: param,
     };
 

--- a/src/lib/parameter-data.ts
+++ b/src/lib/parameter-data.ts
@@ -1,0 +1,362 @@
+import type { Collection } from 'mongodb';
+
+import { getCollection, isMongoConfigured } from '@/lib/mongodb';
+import type { Parameter } from '@/lib/types';
+import { emitParameterUpdate } from '@/lib/realtime';
+
+type ParameterDisplayType = Parameter['displayType'];
+
+type ParameterSeriesEntry = {
+  timestamp: Date;
+  value: number;
+};
+
+type ParameterDataRecord = {
+  dashboard: string;
+  parameterId: string;
+  displayType: ParameterDisplayType;
+  value: number;
+  previousValue: number;
+  series: ParameterSeriesEntry[];
+  updatedAt: Date;
+};
+
+type ParameterDescriptor = {
+  id: string;
+  displayType?: ParameterDisplayType;
+};
+
+type EnsureOptions = {
+  initialize: boolean;
+};
+
+const PARAMETER_COLLECTION = 'dashboardParameters';
+const MAX_SERIES_LENGTH = 20;
+const DEFAULT_MIN = 5;
+const DEFAULT_MAX = 95;
+
+const memoryStore = new Map<string, ParameterDataRecord>();
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function randomBetween(min: number, max: number): number {
+  return Math.random() * (max - min) + min;
+}
+
+function getMemoryKey(dashboard: string, parameterId: string): string {
+  return `${dashboard}::${parameterId}`;
+}
+
+function cloneSeries(series: ParameterSeriesEntry[]): ParameterSeriesEntry[] {
+  return series.map((entry) => ({ timestamp: new Date(entry.timestamp), value: entry.value }));
+}
+
+async function getParameterCollection(): Promise<Collection<ParameterDataRecord> | null> {
+  if (!isMongoConfigured()) {
+    return null;
+  }
+
+  try {
+    return await getCollection<ParameterDataRecord>(PARAMETER_COLLECTION);
+  } catch (error) {
+    console.error('Failed to access MongoDB parameter collection:', error);
+    return null;
+  }
+}
+
+function ensurePreviousValue(record: ParameterDataRecord, fallback: number): number {
+  return Number.isFinite(record.previousValue) ? record.previousValue : fallback;
+}
+
+function createInitialRecord(
+  dashboard: string,
+  descriptor: Required<ParameterDescriptor>,
+): ParameterDataRecord {
+  const now = new Date();
+  const baseValue = randomBetween(DEFAULT_MIN, DEFAULT_MAX);
+
+  if (descriptor.displayType === 'line' || descriptor.displayType === 'bar') {
+    const series: ParameterSeriesEntry[] = [];
+    let runningValue = baseValue;
+
+    for (let index = MAX_SERIES_LENGTH - 1; index >= 0; index -= 1) {
+      runningValue = clamp(runningValue + (Math.random() - 0.5) * 6, 0, 100);
+      series.unshift({
+        timestamp: new Date(now.getTime() - index * 1000),
+        value: runningValue,
+      });
+    }
+
+    const currentValue = series[series.length - 1]?.value ?? baseValue;
+
+    return {
+      dashboard,
+      parameterId: descriptor.id,
+      displayType: descriptor.displayType,
+      value: currentValue,
+      previousValue: currentValue,
+      series,
+      updatedAt: now,
+    };
+  }
+
+  return {
+    dashboard,
+    parameterId: descriptor.id,
+    displayType: descriptor.displayType,
+    value: baseValue,
+    previousValue: baseValue,
+    series: [],
+    updatedAt: now,
+  };
+}
+
+function normalizeRecord(raw: ParameterDataRecord): ParameterDataRecord {
+  return {
+    dashboard: raw.dashboard,
+    parameterId: raw.parameterId,
+    displayType: raw.displayType,
+    value: Number.isFinite(raw.value) ? raw.value : 0,
+    previousValue: Number.isFinite(raw.previousValue) ? raw.previousValue : raw.value ?? 0,
+    series: Array.isArray(raw.series)
+      ? raw.series.map((entry) => ({
+          timestamp: entry.timestamp instanceof Date ? entry.timestamp : new Date(entry.timestamp),
+          value: Number.isFinite(entry.value) ? entry.value : 0,
+        }))
+      : [],
+    updatedAt: raw.updatedAt instanceof Date ? raw.updatedAt : new Date(raw.updatedAt),
+  };
+}
+
+async function loadRecord(dashboard: string, parameterId: string): Promise<ParameterDataRecord | null> {
+  const collection = await getParameterCollection();
+
+  if (collection) {
+    const document = await collection.findOne({ dashboard, parameterId });
+    if (document) {
+      return normalizeRecord(document);
+    }
+  }
+
+  const memoryRecord = memoryStore.get(getMemoryKey(dashboard, parameterId));
+  return memoryRecord ? normalizeRecord(memoryRecord) : null;
+}
+
+async function persistRecord(record: ParameterDataRecord): Promise<void> {
+  const key = getMemoryKey(record.dashboard, record.parameterId);
+  memoryStore.set(key, normalizeRecord(record));
+
+  const collection = await getParameterCollection();
+  if (!collection) {
+    return;
+  }
+
+  try {
+    await collection.updateOne(
+      { dashboard: record.dashboard, parameterId: record.parameterId },
+      {
+        $set: {
+          displayType: record.displayType,
+          value: record.value,
+          previousValue: record.previousValue,
+          series: record.series,
+          updatedAt: record.updatedAt,
+        },
+      },
+      { upsert: true },
+    );
+  } catch (error) {
+    console.error(`Failed to persist parameter ${record.parameterId} for ${record.dashboard}:`, error);
+  }
+}
+
+async function ensureRecord(
+  dashboard: string,
+  descriptor: ParameterDescriptor,
+  options: EnsureOptions,
+): Promise<ParameterDataRecord | null> {
+  const existing = await loadRecord(dashboard, descriptor.id);
+  if (existing) {
+    return existing;
+  }
+
+  if (!options.initialize) {
+    return null;
+  }
+
+  if (!descriptor.displayType) {
+    throw new Error('Display type is required to initialize parameter data.');
+  }
+
+  const created = createInitialRecord(dashboard, descriptor as Required<ParameterDescriptor>);
+  await persistRecord(created);
+  return created;
+}
+
+function applySimulationStep(record: ParameterDataRecord): ParameterDataRecord {
+  const next: ParameterDataRecord = {
+    ...record,
+    series: cloneSeries(record.series),
+    previousValue: ensurePreviousValue(record, record.value),
+    updatedAt: new Date(),
+  };
+
+  const baseValue = Number.isFinite(record.value) ? record.value : 50;
+
+  switch (record.displayType) {
+    case 'line':
+    case 'bar': {
+      const lastValue = next.series[next.series.length - 1]?.value ?? baseValue;
+      const mutated = clamp(lastValue + (Math.random() - 0.5) * 6, 0, 100);
+      next.value = mutated;
+      next.previousValue = lastValue;
+      next.series.push({ timestamp: next.updatedAt, value: mutated });
+      if (next.series.length > MAX_SERIES_LENGTH) {
+        next.series = next.series.slice(-MAX_SERIES_LENGTH);
+      }
+      break;
+    }
+    case 'stat': {
+      const mutated = clamp(baseValue + (Math.random() - 0.5) * 10, 0, 100);
+      next.previousValue = baseValue;
+      next.value = mutated;
+      break;
+    }
+    default: {
+      const mutated = clamp(baseValue + (Math.random() - 0.5) * 10, 0, 100);
+      next.previousValue = baseValue;
+      next.value = mutated;
+      break;
+    }
+  }
+
+  return next;
+}
+
+function applyExternalValue(
+  record: ParameterDataRecord,
+  value: number,
+  timestamp: Date,
+): ParameterDataRecord {
+  const normalizedValue = clamp(value, 0, 100);
+
+  const next: ParameterDataRecord = {
+    ...record,
+    series: cloneSeries(record.series),
+    previousValue: ensurePreviousValue(record, record.value),
+    value: normalizedValue,
+    updatedAt: timestamp,
+  };
+
+  switch (record.displayType) {
+    case 'line':
+    case 'bar': {
+      next.series.push({ timestamp, value: normalizedValue });
+      if (next.series.length > MAX_SERIES_LENGTH) {
+        next.series = next.series.slice(-MAX_SERIES_LENGTH);
+      }
+      next.previousValue = record.series.at(-1)?.value ?? record.value ?? normalizedValue;
+      break;
+    }
+    case 'stat': {
+      next.previousValue = record.value ?? normalizedValue;
+      break;
+    }
+    default: {
+      next.previousValue = record.value ?? normalizedValue;
+    }
+  }
+
+  return next;
+}
+
+function toResponsePayload(record: ParameterDataRecord): unknown {
+  switch (record.displayType) {
+    case 'line':
+      return record.series.map((entry) => ({
+        time: entry.timestamp.getTime(),
+        value: entry.value,
+      }));
+    case 'bar':
+      return record.series.map((entry, index) => ({
+        name: `Point ${index + 1}`,
+        value: entry.value,
+      }));
+    case 'stat':
+      return {
+        value: record.value,
+        previousValue: ensurePreviousValue(record, record.value),
+      };
+    default:
+      return record.value;
+  }
+}
+
+export async function getParameterData(
+  dashboard: string,
+  descriptor: ParameterDescriptor,
+  options: Partial<EnsureOptions> = { initialize: true },
+): Promise<unknown | null> {
+  const record = await ensureRecord(dashboard, descriptor, {
+    initialize: options.initialize ?? true,
+  });
+
+  if (!record) {
+    return null;
+  }
+
+  return toResponsePayload(record);
+}
+
+const SIMULATION_ENABLED = process.env.PARAMETER_DATA_SIMULATION !== 'off';
+
+export async function stepParameterSimulation(
+  dashboard: string,
+  descriptor: ParameterDescriptor,
+): Promise<unknown | null> {
+  const record = await ensureRecord(dashboard, descriptor, { initialize: true });
+  if (!record) {
+    return null;
+  }
+
+  const nextRecord = applySimulationStep(record);
+  await persistRecord(nextRecord);
+
+  const payload = toResponsePayload(nextRecord);
+  emitParameterUpdate({ dashboard, parameterId: descriptor.id, data: payload });
+
+  return payload;
+}
+
+export async function maybeSimulateParameter(
+  dashboard: string,
+  descriptor: ParameterDescriptor,
+): Promise<unknown | null> {
+  if (!SIMULATION_ENABLED) {
+    return getParameterData(dashboard, descriptor, { initialize: true });
+  }
+
+  return stepParameterSimulation(dashboard, descriptor);
+}
+
+export async function recordParameterValue(
+  dashboard: string,
+  descriptor: ParameterDescriptor,
+  value: number,
+  timestamp: Date = new Date(),
+): Promise<unknown> {
+  const record = await ensureRecord(dashboard, descriptor, { initialize: !!descriptor.displayType });
+  if (!record) {
+    throw new Error('Parameter record does not exist. Provide a display type to initialize it.');
+  }
+
+  const nextRecord = applyExternalValue(record, value, timestamp);
+  await persistRecord(nextRecord);
+
+  const payload = toResponsePayload(nextRecord);
+  emitParameterUpdate({ dashboard, parameterId: descriptor.id, data: payload });
+
+  return payload;
+}

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from 'events';
+
+type ParameterUpdatePayload = {
+  dashboard: string;
+  parameterId: string;
+  data: unknown;
+};
+
+type ParameterListener = (payload: ParameterUpdatePayload) => void;
+
+type GlobalRealtimeStore = typeof globalThis & {
+  __parameterEmitter?: EventEmitter;
+};
+
+const globalStore = globalThis as GlobalRealtimeStore;
+
+const emitter =
+  globalStore.__parameterEmitter ?? (globalStore.__parameterEmitter = new EventEmitter());
+
+// Allow any number of listeners – dashboards can have many widgets subscribed.
+emitter.setMaxListeners(0);
+
+function getParameterKey(dashboard: string, parameterId: string): string {
+  return `${dashboard}::${parameterId}`;
+}
+
+export function emitParameterUpdate(payload: ParameterUpdatePayload): void {
+  emitter.emit(getParameterKey(payload.dashboard, payload.parameterId), payload);
+}
+
+export function subscribeToParameter(
+  dashboard: string,
+  parameterId: string,
+  listener: ParameterListener,
+): () => void {
+  const key = getParameterKey(dashboard, parameterId);
+  emitter.on(key, listener);
+  return () => {
+    emitter.off(key, listener);
+  };
+}


### PR DESCRIPTION
## Summary
- persist dashboard parameter readings in MongoDB (with in-memory fallback) and emit realtime updates through a shared event bus
- expose REST and SSE endpoints for per-dashboard parameter updates and wire widgets to consume data via an SSE-aware hook
- scope control state to dashboards, update client controls accordingly, and tighten Web Serial typings

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cc670085fc8325831efe8948bba7f2