### PR TITLE
Read dashboard parameters and controls from per-dashboard Mongo collections

### DIFF
--- a/src/actions/control-events.ts
+++ b/src/actions/control-events.ts
@@ -2,14 +2,14 @@
 
 import { Collection } from 'mongodb';
 
+import { getControlCollectionName } from '@/lib/dashboard-storage';
 import { getCollection, isMongoConfigured } from '@/lib/mongodb';
 import type { Control } from '@/lib/types';
-
-const CONTROL_STATE_COLLECTION = 'controlStates';
 
 type ControlType = Control['type'];
 
 export type SetControlStateInput = {
+  dashboardName: string;
   controlId: string;
   type: ControlType;
   value: unknown;
@@ -30,14 +30,16 @@ export type SetControlStateResult = {
 };
 
 interface ControlStateDocument {
+  dashboard: string;
   controlId: string;
   type: ControlType;
-  value: any;
+  value: unknown;
   updatedAt: Date;
   lastError?: string | null;
 }
 
 type ControlStateRecord = {
+  dashboard: string;
   controlId: string;
   type: ControlType;
   value: unknown;
@@ -51,28 +53,38 @@ type IntegrationResult = {
   message?: string;
 };
 
-const globalStore = globalThis as typeof globalThis & {
+type ControlStateStore = typeof globalThis & {
   __controlStateStore?: Map<string, ControlStateRecord>;
 };
+
+const globalStore = globalThis as ControlStateStore;
 
 const inMemoryStore =
   globalStore.__controlStateStore ?? (globalStore.__controlStateStore = new Map<string, ControlStateRecord>());
 
-async function getControlStateCollection(): Promise<Collection<ControlStateDocument> | null> {
+function getStoreKey(dashboard: string, controlId: string): string {
+  return `${dashboard}::${controlId}`;
+}
+
+async function getControlStateCollection(
+  dashboard: string,
+): Promise<Collection<ControlStateDocument> | null> {
   if (!isMongoConfigured()) {
     return null;
   }
 
   try {
-    return await getCollection<ControlStateDocument>(CONTROL_STATE_COLLECTION);
+    const collectionName = getControlCollectionName(dashboard);
+    return await getCollection<ControlStateDocument>(collectionName);
   } catch (error) {
-    console.error('Failed to access MongoDB control state collection:', error);
+    console.error(`Failed to access MongoDB control state collection for ${dashboard}:`, error);
     return null;
   }
 }
 
 function toRecord(document: ControlStateDocument): ControlStateRecord {
   return {
+    dashboard: document.dashboard,
     controlId: document.controlId,
     type: document.type,
     value: document.value,
@@ -92,11 +104,11 @@ function toSnapshot(record: ControlStateRecord): ControlStateSnapshot {
 }
 
 async function persistControlState(record: ControlStateRecord): Promise<void> {
-  const collection = await getControlStateCollection();
+  const collection = await getControlStateCollection(record.dashboard);
   if (collection) {
     try {
       await collection.updateOne(
-        { controlId: record.controlId },
+        { dashboard: record.dashboard, controlId: record.controlId },
         {
           $set: {
             type: record.type,
@@ -108,11 +120,14 @@ async function persistControlState(record: ControlStateRecord): Promise<void> {
         { upsert: true },
       );
     } catch (error) {
-      console.error('Failed to persist control state to MongoDB:', error);
+      console.error(
+        `Failed to persist control state to MongoDB for ${record.dashboard}/${record.controlId}:`,
+        error,
+      );
     }
   }
 
-  inMemoryStore.set(record.controlId, record);
+  inMemoryStore.set(getStoreKey(record.dashboard, record.controlId), record);
 }
 
 function normalizeError(error: unknown, fallback: string): string {
@@ -142,7 +157,7 @@ async function relayToArduino(input: SetControlStateInput): Promise<IntegrationR
     });
 
     const rawText = await response.text();
-    let parsed: any = null;
+    let parsed: unknown = null;
 
     if (rawText) {
       try {
@@ -153,16 +168,26 @@ async function relayToArduino(input: SetControlStateInput): Promise<IntegrationR
     }
 
     if (!response.ok) {
-      const message = typeof parsed?.error === 'string' ? parsed.error : `Request failed with status ${response.status}`;
+      const parsedObject = typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : null;
+      const message =
+        parsedObject && typeof parsedObject.error === 'string'
+          ? parsedObject.error
+          : `Request failed with status ${response.status}`;
       console.error(`Arduino endpoint responded with status ${response.status}:`, message);
       return {
         success: false,
-        value: parsed?.value,
+        value: parsedObject && 'value' in parsedObject ? parsedObject.value : undefined,
         message,
       };
     }
 
-    const resolvedValue = parsed?.value ?? parsed?.state ?? parsed ?? input.value;
+    const parsedObject = typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : null;
+    const resolvedValue =
+      parsedObject && 'value' in parsedObject
+        ? parsedObject.value
+        : parsedObject && 'state' in parsedObject
+          ? parsedObject.state
+          : parsed ?? input.value;
     return { success: true, value: resolvedValue };
   } catch (error) {
     const message = normalizeError(error, 'Unable to reach the Arduino endpoint.');
@@ -171,20 +196,25 @@ async function relayToArduino(input: SetControlStateInput): Promise<IntegrationR
   }
 }
 
-export async function getControlStates(controlIds: string[]): Promise<Record<string, ControlStateSnapshot>> {
+export async function getControlStates(
+  dashboardName: string,
+  controlIds: string[],
+): Promise<Record<string, ControlStateSnapshot>> {
   if (!Array.isArray(controlIds) || controlIds.length === 0) {
     return {};
   }
 
   const result: Record<string, ControlStateSnapshot> = {};
-  const collection = await getControlStateCollection();
+  const collection = await getControlStateCollection(dashboardName);
 
   if (collection) {
     try {
-      const documents = await collection.find({ controlId: { $in: controlIds } }).toArray();
+      const documents = await collection
+        .find({ dashboard: dashboardName, controlId: { $in: controlIds } })
+        .toArray();
       for (const document of documents) {
         const record = toRecord(document);
-        inMemoryStore.set(record.controlId, record);
+        inMemoryStore.set(getStoreKey(record.dashboard, record.controlId), record);
         result[record.controlId] = toSnapshot(record);
       }
     } catch (error) {
@@ -194,7 +224,7 @@ export async function getControlStates(controlIds: string[]): Promise<Record<str
 
   for (const id of controlIds) {
     if (!result[id]) {
-      const record = inMemoryStore.get(id);
+      const record = inMemoryStore.get(getStoreKey(dashboardName, id));
       if (record) {
         result[id] = toSnapshot(record);
       }
@@ -205,6 +235,12 @@ export async function getControlStates(controlIds: string[]): Promise<Record<str
 }
 
 export async function setControlState(input: SetControlStateInput): Promise<SetControlStateResult> {
+  if (!input.dashboardName) {
+    const message = 'A dashboard name is required to update control state.';
+    console.error(message, input);
+    return { success: false, error: message };
+  }
+
   if (!input.controlId) {
     const message = 'A controlId is required to update control state.';
     console.error(message, input);
@@ -220,6 +256,7 @@ export async function setControlState(input: SetControlStateInput): Promise<SetC
   try {
     const integration = await relayToArduino(input);
     const record: ControlStateRecord = {
+      dashboard: input.dashboardName,
       controlId: input.controlId,
       type: input.type,
       value: integration.value ?? input.value,
@@ -244,9 +281,13 @@ export async function setControlState(input: SetControlStateInput): Promise<SetC
     };
   } catch (error) {
     const message = normalizeError(error, 'Unexpected failure while updating the control.');
-    console.error(`Unhandled error while setting control state for ${input.controlId}:`, error);
+    console.error(
+      `Unhandled error while setting control state for ${input.dashboardName}/${input.controlId}:`,
+      error,
+    );
 
     const record: ControlStateRecord = {
+      dashboard: input.dashboardName,
       controlId: input.controlId,
       type: input.type,
       value: input.value,

--- a/src/actions/data.ts
+++ b/src/actions/data.ts
@@ -1,97 +1,26 @@
 'use server';
 
-import { Parameter } from "@/lib/types";
-
-// This is a map to store the "current" server-side value for each parameter.
-// In a real application, this would be replaced by a database or a real-time data source.
-const parameterDataStore = new Map<string, any>();
-
-function initializeParameterData(parameterId: string, displayType: Parameter['displayType']) {
-    switch (displayType) {
-        case 'line':
-        case 'bar':
-            // For charts, initialize with an array of data points
-            parameterDataStore.set(parameterId, 
-                Array.from({ length: 10 }, (_, i) => ({
-                    name: `Point ${i + 1}`,
-                    value: Math.random() * 80 + 10,
-                }))
-            );
-            break;
-        case 'stat':
-            // For stats, initialize with a value and a previous value
-            const initialValue = Math.random() * 80 + 10;
-            parameterDataStore.set(parameterId, {
-                value: initialValue,
-                previousValue: initialValue,
-            });
-            break;
-        default:
-            // For gauges, progress bars, etc.
-             parameterDataStore.set(parameterId, Math.random() * 100);
-    }
-}
-
-function getNextData(parameter: Parameter) {
-    const { id, displayType } = parameter;
-
-    if (!parameterDataStore.has(id)) {
-        initializeParameterData(id, displayType);
-    }
-
-    const currentValue = parameterDataStore.get(id);
-
-    switch (displayType) {
-        case 'line':
-        case 'bar':
-            const newDataSet = [...currentValue];
-            const lastValue = newDataSet[newDataSet.length - 1]?.value || 50;
-            const change = (Math.random() - 0.5) * 5;
-            let newValue = lastValue + change;
-            if (newValue < 0) newValue = 0;
-            if (newValue > 100) newValue = 100;
-            const newDataPoint = { time: (newDataSet[newDataSet.length - 1]?.time || 0) + 1, value: newValue };
-            
-            newDataSet.push(newDataPoint);
-            if (newDataSet.length > 20) {
-              newDataSet.shift();
-            }
-            parameterDataStore.set(id, newDataSet);
-            break;
-        case 'stat':
-             const changeStat = (Math.random() - 0.5) * 10;
-             let newStatValue = currentValue.value + changeStat;
-             if (newStatValue < 0) newStatValue = 0;
-             if (newStatValue > 100) newStatValue = 100;
-             parameterDataStore.set(id, { value: newStatValue, previousValue: currentValue.value });
-            break;
-        default:
-             const changeDefault = (Math.random() - 0.5) * 10;
-             let newDefaultValue = currentValue + changeDefault;
-             if (newDefaultValue < 0) newDefaultValue = 0;
-             if (newDefaultValue > 100) newDefaultValue = 100;
-             parameterDataStore.set(id, newDefaultValue);
-    }
-    
-    return parameterDataStore.get(id);
-}
-
+import { getParameterData } from '@/lib/parameter-data';
+import type { Parameter } from '@/lib/types';
 
 /**
- * Fetches the latest data for a given parameter.
- * This is a server action that simulates fetching data from a backend service.
- * @param parameter The parameter to fetch data for.
- * @returns The latest data for the parameter.
+ * Fetches the latest data for a given parameter on the specified dashboard.
+ * Data is read directly from the dashboard's MongoDB collection. If the
+ * database is unavailable or no data exists yet, the caller receives `null`.
  */
-export async function getLatestParameterData(parameter: Parameter): Promise<any> {
-    try {
-        // In a real-world scenario, you would fetch data from a database, an IoT device, or an external API.
-        // For this demo, we'll generate a new "random" value based on the previous one to simulate real-time changes.
-        const data = getNextData(parameter);
-        return data;
-    } catch (error) {
-        console.error(`Failed to fetch data for parameter ${parameter.id}:`, error);
-        // In a real app, you might want to return a specific error object.
-        return null;
-    }
+export async function getLatestParameterData(
+  dashboardName: string,
+  parameter: Parameter,
+): Promise<unknown> {
+  try {
+    const payload = await getParameterData(dashboardName, {
+      id: parameter.id,
+      name: parameter.name,
+      displayType: parameter.displayType,
+    });
+    return payload;
+  } catch (error) {
+    console.error(`Failed to fetch data for parameter ${parameter.id}:`, error);
+    return null;
+  }
 }

--- a/src/app/api/dashboards/[dashboard]/parameters/[parameterId]/route.ts
+++ b/src/app/api/dashboards/[dashboard]/parameters/[parameterId]/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getParameterData } from '@/lib/parameter-data';
+import type { Parameter } from '@/lib/types';
+
+type RouteParams = { dashboard: string; parameterId: string };
+
+type HandlerContext = { params: Promise<RouteParams> };
+
+function decodeParam(value: string): string {
+  return decodeURIComponent(value);
+}
+
+const DISPLAY_TYPES = new Set<Parameter['displayType']>([
+  'radial-gauge',
+  'line',
+  'stat',
+  'bar',
+  'progress',
+  'linear-gauge',
+  'status-light',
+]);
+
+function parseDisplayType(raw: string | null): Parameter['displayType'] {
+  if (!raw) {
+    return 'stat';
+  }
+  const candidate = raw as Parameter['displayType'];
+  return DISPLAY_TYPES.has(candidate) ? candidate : 'stat';
+}
+
+function parseOptionalName(raw: string | null): string | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const value = raw.trim();
+  return value ? value : undefined;
+}
+
+export async function GET(request: NextRequest, context: HandlerContext) {
+  const { dashboard, parameterId } = await context.params;
+  const dashboardName = decodeParam(dashboard);
+  const id = decodeParam(parameterId);
+  const url = new URL(request.url);
+  const displayType = parseDisplayType(url.searchParams.get('displayType'));
+  const parameterName = parseOptionalName(url.searchParams.get('name'));
+
+  try {
+    const data = await getParameterData(dashboardName, {
+      id,
+      name: parameterName,
+      displayType,
+    });
+
+    if (data === null) {
+      return NextResponse.json({ error: 'Parameter not found.' }, { status: 404 });
+    }
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    console.error(`Failed to load parameter ${id} for ${dashboardName}:`, error);
+    return NextResponse.json({ error: 'Unable to load parameter data.' }, { status: 500 });
+  }
+}
+
+export async function POST() {
+  return NextResponse.json(
+    { error: 'Parameters are read-only. Update the MongoDB collection to change their values.' },
+    { status: 405, headers: { Allow: 'GET' } },
+  );
+}

--- a/src/app/api/dashboards/[dashboard]/parameters/[parameterId]/stream/route.ts
+++ b/src/app/api/dashboards/[dashboard]/parameters/[parameterId]/stream/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest } from 'next/server';
+
+import { getParameterData } from '@/lib/parameter-data';
+import type { Parameter } from '@/lib/types';
+
+const encoder = new TextEncoder();
+const POLL_INTERVAL_MS = Math.max(
+  1000,
+  Number(process.env.PARAMETER_STREAM_POLL_INTERVAL_MS ?? '3000'),
+);
+
+type RouteParams = { dashboard: string; parameterId: string };
+
+type HandlerContext = { params: Promise<RouteParams> };
+
+function decodeParam(value: string): string {
+  return decodeURIComponent(value);
+}
+
+const DISPLAY_TYPES = new Set<Parameter['displayType']>([
+  'radial-gauge',
+  'line',
+  'stat',
+  'bar',
+  'progress',
+  'linear-gauge',
+  'status-light',
+]);
+
+function parseDisplayType(raw: string | null): Parameter['displayType'] {
+  if (!raw) {
+    return 'stat';
+  }
+  const candidate = raw as Parameter['displayType'];
+  return DISPLAY_TYPES.has(candidate) ? candidate : 'stat';
+}
+
+function parseOptionalName(raw: string | null): string | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const value = raw.trim();
+  return value ? value : undefined;
+}
+
+function pushEvent(controller: ReadableStreamDefaultController<Uint8Array>, payload: unknown) {
+  const data = JSON.stringify({ data: payload });
+  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+}
+
+export async function GET(request: NextRequest, context: HandlerContext) {
+  const { dashboard, parameterId } = await context.params;
+  const dashboardName = decodeParam(dashboard);
+  const id = decodeParam(parameterId);
+  const url = new URL(request.url);
+  const displayType = parseDisplayType(url.searchParams.get('displayType'));
+  const parameterName = parseOptionalName(url.searchParams.get('name'));
+
+  try {
+    const initial = await getParameterData(dashboardName, { id, name: parameterName, displayType });
+
+    if (initial === null) {
+      return new Response('Parameter not found.', { status: 404 });
+    }
+
+    let cleanup: (() => void) | null = null;
+    let lastSerialized = JSON.stringify(initial);
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        pushEvent(controller, initial);
+
+        let pollTimer: ReturnType<typeof setInterval> | null = null;
+        let isPolling = false;
+
+        const poll = async () => {
+          if (isPolling) {
+            return;
+          }
+          isPolling = true;
+          try {
+            const next = await getParameterData(dashboardName, {
+              id,
+              name: parameterName,
+              displayType,
+            });
+
+            if (next === null) {
+              return;
+            }
+
+            const serialized = JSON.stringify(next);
+            if (serialized !== lastSerialized) {
+              lastSerialized = serialized;
+              pushEvent(controller, next);
+            }
+          } catch (error) {
+            console.error(`Failed to poll parameter ${dashboardName}/${id}:`, error);
+          } finally {
+            isPolling = false;
+          }
+        };
+
+        pollTimer = setInterval(() => {
+          poll().catch((error) => {
+            console.error(`Unhandled error while polling ${dashboardName}/${id}:`, error);
+          });
+        }, POLL_INTERVAL_MS);
+
+        const keepAlive = setInterval(() => {
+          controller.enqueue(encoder.encode(':keep-alive\n\n'));
+        }, 15000);
+
+        cleanup = () => {
+          const handler = cleanup;
+          cleanup = null;
+          if (pollTimer) {
+            clearInterval(pollTimer);
+          }
+          clearInterval(keepAlive);
+          controller.close();
+          if (handler) {
+            request.signal.removeEventListener('abort', handler);
+          }
+        };
+
+        request.signal.addEventListener('abort', cleanup);
+        // Trigger an immediate poll to capture any updates that occurred between the
+        // initial read and establishing the stream.
+        poll().catch((error) => {
+          console.error(`Unhandled error while polling ${dashboardName}/${id}:`, error);
+        });
+      },
+      cancel() {
+        if (cleanup) {
+          cleanup();
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+      },
+    });
+  } catch (error) {
+    console.error(`Failed to start parameter stream for ${dashboardName}/${id}:`, error);
+    return new Response('Unable to start stream.', { status: 500 });
+  }
+}

--- a/src/app/dashboard/[name]/page.tsx
+++ b/src/app/dashboard/[name]/page.tsx
@@ -23,7 +23,10 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
   }
 
   const config = await getConfiguration(configName);
-  const controlStates = await getControlStates(config.controls.map((control) => control.id));
+  const controlStates = await getControlStates(
+    config.name,
+    config.controls.map((control) => control.id),
+  );
 
   if (config.parameters.length === 0) {
     return (
@@ -47,6 +50,7 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
         <h1 className="text-3xl font-bold">{config.name}</h1>
         <div className="flex items-center gap-2">
           <DashboardControls
+            dashboardName={config.name}
             controls={config.controls}
             parameters={config.parameters}
             controlStates={controlStates}
@@ -56,7 +60,7 @@ export default async function DisplayDashboardPage({ params }: DisplayDashboardP
           </Button>
         </div>
       </div>
-      <WidgetGrid parameters={config.parameters} />
+      <WidgetGrid dashboardName={config.name} parameters={config.parameters} />
     </div>
   );
 }

--- a/src/components/display/bar-chart.tsx
+++ b/src/components/display/bar-chart.tsx
@@ -8,11 +8,17 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type BarChartComponentProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function BarChartComponent({ parameter }: BarChartComponentProps) {
-  const { data, isLoading } = useParameterData(parameter, []);
+export function BarChartComponent({ dashboardName, parameter }: BarChartComponentProps) {
+  const { data, isLoading } = useParameterData<Array<{ name: string; value: number }>>(
+    dashboardName,
+    parameter,
+    [],
+  );
+  const series = data ?? [];
 
   const chartConfig = {
     value: {
@@ -28,33 +34,33 @@ export function BarChartComponent({ parameter }: BarChartComponentProps) {
       description={`Bar chart for ${parameter.name.toLowerCase()}.`}
       contentClassName="pl-0 pr-4 pb-4"
     >
-        {isLoading && data.length === 0 ? (
+      {isLoading && series.length === 0 ? (
         <div className="p-6 h-full w-full flex items-center justify-center">
-            <Skeleton className="h-full w-full" />
+          <Skeleton className="h-full w-full" />
         </div>
-        ) : (
-      <ChartContainer config={chartConfig} className="h-full w-full">
-        <RechartsBarChart
-          accessibilityLayer
-          data={data}
-          layout="horizontal"
-          margin={{ top: 5, right: 10, left: 10, bottom: 0 }}
-        >
-          <CartesianGrid vertical={false} />
-          <XAxis dataKey="name" tickLine={false} axisLine={false} tickMargin={8} tickFormatter={() => ''} />
-          <ChartTooltip
-            cursor={false}
-            content={
-              <ChartTooltipContent
-                indicator="dot"
-                formatter={(value) => `${Number(value).toFixed(1)} ${parameter.unit || ''}`}
-              />
-            }
-          />
-          <Bar dataKey="value" fill="var(--color-value)" radius={4} />
-        </RechartsBarChart>
-      </ChartContainer>
-        )}
+      ) : (
+        <ChartContainer config={chartConfig} className="h-full w-full">
+          <RechartsBarChart
+            accessibilityLayer
+            data={series}
+            layout="horizontal"
+            margin={{ top: 5, right: 10, left: 10, bottom: 0 }}
+          >
+            <CartesianGrid vertical={false} />
+            <XAxis dataKey="name" tickLine={false} axisLine={false} tickMargin={8} tickFormatter={() => ''} />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  indicator="dot"
+                  formatter={(value) => `${Number(value).toFixed(1)} ${parameter.unit || ''}`}
+                />
+              }
+            />
+            <Bar dataKey="value" fill="var(--color-value)" radius={4} />
+          </RechartsBarChart>
+        </ChartContainer>
+      )}
     </WidgetCardWrapper>
   );
 }

--- a/src/components/display/gauge-chart.tsx
+++ b/src/components/display/gauge-chart.tsx
@@ -8,25 +8,27 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type RadialGaugeProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function RadialGauge({ parameter }: RadialGaugeProps) {
-    const { data: value, isLoading } = useParameterData(parameter, 50);
+export function RadialGauge({ dashboardName, parameter }: RadialGaugeProps) {
+  const { data: rawValue, isLoading } = useParameterData<number>(dashboardName, parameter, 50);
 
-    if (isLoading) {
+  if (isLoading) {
     return (
-        <WidgetCardWrapper
+      <WidgetCardWrapper
         title={parameter.name}
         icon={parameter.icon}
         description={parameter.description}
         contentClassName="flex items-center justify-center p-4"
-        >
+      >
         <Skeleton className="aspect-square h-full w-full rounded-full" />
-        </WidgetCardWrapper>
+      </WidgetCardWrapper>
     );
-    }
+  }
 
+  const value = rawValue ?? 0;
 
   const percentage = value / 100;
   const size = 200;

--- a/src/components/display/line-chart.tsx
+++ b/src/components/display/line-chart.tsx
@@ -8,11 +8,17 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type LineChartComponentProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function LineChartComponent({ parameter }: LineChartComponentProps) {
-  const { data, isLoading } = useParameterData(parameter, []);
+export function LineChartComponent({ dashboardName, parameter }: LineChartComponentProps) {
+  const { data, isLoading } = useParameterData<Array<{ time: number; value: number }>>(
+    dashboardName,
+    parameter,
+    [],
+  );
+  const series = data ?? [];
 
   const chartConfig = {
     value: {
@@ -28,33 +34,33 @@ export function LineChartComponent({ parameter }: LineChartComponentProps) {
       description={`Live trend for ${parameter.name.toLowerCase()}.`}
       contentClassName="pl-0 pr-4 pb-4"
     >
-      {isLoading && data.length === 0 ? (
+      {isLoading && series.length === 0 ? (
         <div className="p-6 h-full w-full flex items-center justify-center">
-            <Skeleton className="h-full w-full" />
+          <Skeleton className="h-full w-full" />
         </div>
       ) : (
-      <ChartContainer config={chartConfig} className="h-full w-full">
-        <AreaChart data={data} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
-          <CartesianGrid vertical={false} />
-          <XAxis dataKey="time" tickLine={false} axisLine={false} tickMargin={8} tickFormatter={() => ''} />
-          <ChartTooltip
-            cursor={false}
-            content={
-              <ChartTooltipContent
-                indicator="dot"
-                formatter={(value) => `${Number(value).toFixed(1)} ${parameter.unit || ''}`}
-              />
-            }
-          />
-          <defs>
-            <linearGradient id="fillValue" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="var(--color-value)" stopOpacity={0.8} />
-              <stop offset="95%" stopColor="var(--color-value)" stopOpacity={0.1} />
-            </linearGradient>
-          </defs>
-          <Area dataKey="value" type="natural" fill="url(#fillValue)" stroke="var(--color-value)" stackId="a" />
-        </AreaChart>
-      </ChartContainer>
+        <ChartContainer config={chartConfig} className="h-full w-full">
+          <AreaChart data={series} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
+            <CartesianGrid vertical={false} />
+            <XAxis dataKey="time" tickLine={false} axisLine={false} tickMargin={8} tickFormatter={() => ''} />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  indicator="dot"
+                  formatter={(value) => `${Number(value).toFixed(1)} ${parameter.unit || ''}`}
+                />
+              }
+            />
+            <defs>
+              <linearGradient id="fillValue" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="var(--color-value)" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="var(--color-value)" stopOpacity={0.1} />
+              </linearGradient>
+            </defs>
+            <Area dataKey="value" type="natural" fill="url(#fillValue)" stroke="var(--color-value)" stackId="a" />
+          </AreaChart>
+        </ChartContainer>
       )}
     </WidgetCardWrapper>
   );

--- a/src/components/display/linear-gauge.tsx
+++ b/src/components/display/linear-gauge.tsx
@@ -7,11 +7,13 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type LinearGaugeProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function LinearGauge({ parameter }: LinearGaugeProps) {
-  const { data: value, isLoading } = useParameterData(parameter, 50);
+export function LinearGauge({ dashboardName, parameter }: LinearGaugeProps) {
+  const { data, isLoading } = useParameterData<number>(dashboardName, parameter, 50);
+  const value = data ?? 0;
 
   const percentage = (value / 100) * 100;
 

--- a/src/components/display/progress-bar.tsx
+++ b/src/components/display/progress-bar.tsx
@@ -7,11 +7,13 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type ProgressBarProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function ProgressBar({ parameter }: ProgressBarProps) {
-  const { data: value, isLoading } = useParameterData(parameter, 50);
+export function ProgressBar({ dashboardName, parameter }: ProgressBarProps) {
+  const { data, isLoading } = useParameterData<number>(dashboardName, parameter, 50);
+  const value = data ?? 0;
 
   return (
     <WidgetCardWrapper title={parameter.name} icon={parameter.icon} contentClassName="flex flex-col justify-center space-y-4">

--- a/src/components/display/stat-card.tsx
+++ b/src/components/display/stat-card.tsx
@@ -8,11 +8,16 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type StatCardProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function StatCard({ parameter }: StatCardProps) {
-  const { data, isLoading } = useParameterData(parameter);
+export function StatCard({ dashboardName, parameter }: StatCardProps) {
+  const { data, isLoading } = useParameterData<{ value: number; previousValue: number }>(
+    dashboardName,
+    parameter,
+    null,
+  );
 
   if (isLoading || !data) {
     return (
@@ -23,8 +28,8 @@ export function StatCard({ parameter }: StatCardProps) {
         contentClassName="flex flex-col items-center justify-center"
       >
         <div className="h-full flex flex-col items-center justify-center gap-2">
-            <Skeleton className="h-10 w-24" />
-            <Skeleton className="h-5 w-16" />
+          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-5 w-16" />
         </div>
       </WidgetCardWrapper>
     );
@@ -46,11 +51,7 @@ export function StatCard({ parameter }: StatCardProps) {
         <p className="font-bold text-4xl">
           {value.toFixed(1)}
         </p>
-        <span
-          className="ml-2 text-muted-foreground text-xl"
-        >
-          {parameter.unit}
-        </span>
+        <span className="ml-2 text-muted-foreground text-xl">{parameter.unit}</span>
       </div>
       <div
         className={cn(

--- a/src/components/display/status-light.tsx
+++ b/src/components/display/status-light.tsx
@@ -7,11 +7,13 @@ import { useParameterData } from '@/hooks/use-parameter-data';
 import { Skeleton } from '../ui/skeleton';
 
 type StatusLightProps = {
+  dashboardName: string;
   parameter: Parameter;
 };
 
-export function StatusLight({ parameter }: StatusLightProps) {
-  const { data: value, isLoading } = useParameterData(parameter, 50);
+export function StatusLight({ dashboardName, parameter }: StatusLightProps) {
+  const { data, isLoading } = useParameterData<number>(dashboardName, parameter, 50);
+  const value = data ?? 0;
 
   const getStatus = (val: number) => {
     if (val < 33) return { label: 'OK', color: 'bg-green-500', shadow: 'shadow-[0_0_12px_4px] shadow-green-500/70' };
@@ -33,11 +35,11 @@ export function StatusLight({ parameter }: StatusLightProps) {
       {isLoading ? (
         <Skeleton className={cn('rounded-full', lightSize)} />
       ) : (
-         <div className={cn('relative', lightSize)}>
-            <div className={cn('h-full w-full rounded-full', status.color, status.shadow)} />
+        <div className={cn('relative', lightSize)}>
+          <div className={cn('h-full w-full rounded-full', status.color, status.shadow)} />
         </div>
       )}
-     
+
       <p className={cn('font-semibold', labelSize)}>{isLoading ? <Skeleton className="h-6 w-20" /> : status.label}</p>
       <p className="text-sm text-muted-foreground">
         {isLoading ? '...' : value.toFixed(1)} {parameter.unit}

--- a/src/components/display/widget-grid.tsx
+++ b/src/components/display/widget-grid.tsx
@@ -11,12 +11,14 @@ import { LinearGauge } from './linear-gauge';
 import { StatusLight } from './status-light';
 
 type WidgetGridProps = {
+  dashboardName: string;
   parameters: Parameter[];
 };
 
-export function WidgetGrid({ parameters }: WidgetGridProps) {
+export function WidgetGrid({ dashboardName, parameters }: WidgetGridProps) {
   const renderWidget = (param: Parameter) => {
     const commonProps = {
+      dashboardName,
       parameter: param,
     };
 

--- a/src/hooks/use-parameter-data.ts
+++ b/src/hooks/use-parameter-data.ts
@@ -1,44 +1,140 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useEffect, useState } from 'react';
+
 import { getLatestParameterData } from '@/actions/data';
-import { Parameter } from '@/lib/types';
+import type { Parameter } from '@/lib/types';
 
-const FETCH_INTERVAL_MS = 2500;
+const FALLBACK_FETCH_INTERVAL_MS = 5000;
+const STREAM_RETRY_DELAY_MS = 4000;
 
-export function useParameterData(parameter: Parameter, initialData: any | null = null) {
-  const [data, setData] = useState<any>(initialData);
-  const [isLoading, setIsLoading] = useState(!initialData);
+function hasInitialData(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return value !== null && value !== undefined;
+}
+
+export function useParameterData<T = unknown>(
+  dashboardName: string,
+  parameter: Parameter,
+  initialData: T | null = null,
+) {
+  const [data, setData] = useState<T | null>(initialData);
+  const [isLoading, setIsLoading] = useState(!hasInitialData(initialData));
   const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async () => {
-    try {
-      // Don't set loading to true on subsequent fetches to avoid UI flicker
-      if (!data) {
-        setIsLoading(true);
-      }
-      setError(null);
-      const result = await getLatestParameterData(parameter);
-      setData(result);
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unknown error occurred';
-      setError(errorMessage);
-      console.error(`Failed to fetch data for parameter ${parameter.id}:`, err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [parameter, data]); // Add `data` to dependencies to avoid flicker on first load
+  const parameterId = parameter.id;
+  const displayType = parameter.displayType;
 
   useEffect(() => {
-    // Fetch data immediately on component mount
-    fetchData();
+    let cancelled = false;
+    let eventSource: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let fallbackTimer: ReturnType<typeof setInterval> | null = null;
+    let awaitingFirstFetch = true;
 
-    // Then fetch data at the specified interval
-    const interval = setInterval(fetchData, FETCH_INTERVAL_MS);
+    const stopFallback = () => {
+      if (fallbackTimer) {
+        clearInterval(fallbackTimer);
+        fallbackTimer = null;
+      }
+    };
 
-    // Clean up the interval on component unmount
-    return () => clearInterval(interval);
-  }, [fetchData]);
+    const fetchLatest = async () => {
+      try {
+        if (awaitingFirstFetch) {
+          setIsLoading(true);
+        }
+        setError(null);
+        const result = await getLatestParameterData(dashboardName, parameter);
+        if (cancelled) {
+          return;
+        }
+        if (result !== undefined) {
+          setData((result ?? null) as T | null);
+          setIsLoading(false);
+        }
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        const message = err instanceof Error ? err.message : 'An unknown error occurred';
+        setError(message);
+        console.error(`Failed to fetch data for parameter ${parameterId}:`, err);
+      } finally {
+        awaitingFirstFetch = false;
+      }
+    };
+
+    const startFallback = () => {
+      if (!fallbackTimer) {
+        fallbackTimer = setInterval(fetchLatest, FALLBACK_FETCH_INTERVAL_MS);
+      }
+    };
+
+    const connectStream = () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      const url = new URL(
+        `/api/dashboards/${encodeURIComponent(dashboardName)}/parameters/${encodeURIComponent(parameterId)}/stream`,
+        window.location.origin,
+      );
+      url.searchParams.set('displayType', displayType);
+      url.searchParams.set('name', parameter.name);
+
+      const source = new EventSource(url.toString());
+      eventSource = source;
+
+      source.onopen = () => {
+        stopFallback();
+      };
+
+      source.onmessage = (event) => {
+        try {
+          const payload = JSON.parse(event.data);
+          const nextData = payload?.data ?? payload;
+          if (!cancelled) {
+            setData((nextData ?? null) as T | null);
+            setIsLoading(false);
+            setError(null);
+          }
+        } catch (parseError) {
+          console.error('Failed to parse parameter stream payload:', parseError);
+        }
+      };
+
+      source.onerror = () => {
+        if (cancelled) {
+          return;
+        }
+        source.close();
+        startFallback();
+        reconnectTimer = setTimeout(() => {
+          connectStream();
+        }, STREAM_RETRY_DELAY_MS);
+      };
+    };
+
+    fetchLatest();
+    connectStream();
+
+    return () => {
+      cancelled = true;
+      if (eventSource) {
+        eventSource.close();
+      }
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+      }
+      if (fallbackTimer) {
+        clearInterval(fallbackTimer);
+      }
+    };
+  }, [dashboardName, parameterId, parameter.name, displayType]);
 
   return { data, isLoading, error };
 }

--- a/src/lib/dashboard-storage.ts
+++ b/src/lib/dashboard-storage.ts
@@ -1,0 +1,58 @@
+import type { Parameter } from '@/lib/types';
+
+function normalizeSegment(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return 'dashboard';
+  }
+  return trimmed
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .replace(/_{2,}/g, '_')
+    .slice(0, 120);
+}
+
+export function getParameterCollectionName(dashboard: string): string {
+  return `${normalizeSegment(dashboard)}_parametre`;
+}
+
+export function getControlCollectionName(dashboard: string): string {
+  return `${normalizeSegment(dashboard)}_control`;
+}
+
+export function getParameterFieldCandidates(
+  parameter: Pick<Parameter, 'id'> & { name?: Parameter['name'] },
+): string[] {
+  const candidates = new Set<string>();
+
+  const pushVariants = (value: string | undefined) => {
+    if (!value) {
+      return;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const normalizedWhitespace = trimmed.replace(/\s+/g, ' ');
+    const variants = [
+      normalizedWhitespace,
+      normalizedWhitespace.replace(/\s+/g, '_'),
+      normalizedWhitespace.replace(/\s+/g, ''),
+    ];
+
+    for (const variant of variants) {
+      if (!variant) {
+        continue;
+      }
+      candidates.add(variant);
+      candidates.add(variant.toLowerCase());
+    }
+  };
+
+  pushVariants(parameter.id);
+  pushVariants(parameter.name);
+
+  return Array.from(candidates);
+}

--- a/src/lib/parameter-data.ts
+++ b/src/lib/parameter-data.ts
@@ -1,0 +1,217 @@
+import type { Collection, Document } from 'mongodb';
+import { ObjectId } from 'mongodb';
+
+import { getParameterCollectionName, getParameterFieldCandidates } from '@/lib/dashboard-storage';
+import { getCollection, isMongoConfigured } from '@/lib/mongodb';
+import type { Parameter } from '@/lib/types';
+
+export type ParameterDescriptor = {
+  id: Parameter['id'];
+  displayType: Parameter['displayType'];
+  name?: Parameter['name'];
+};
+
+export type GetParameterDataOptions = {
+  historyLimit?: number;
+};
+
+type ParameterSnapshot = {
+  timestamp: Date;
+  value: number;
+};
+
+interface ParameterDocument extends Document {
+  _id: ObjectId;
+  createdAt?: Date;
+  timestamp?: Date;
+  [key: string]: unknown;
+}
+
+const DEFAULT_HISTORY_LIMIT = 20;
+const FALLBACK_HISTORY_LIMIT = DEFAULT_HISTORY_LIMIT * 2;
+
+const snapshotCache = new Map<string, ParameterSnapshot[]>();
+
+function getCacheKey(dashboard: string, descriptor: ParameterDescriptor): string {
+  return `${dashboard}::${descriptor.id}`;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function resolveTimestamp(document: ParameterDocument): Date {
+  if (document.timestamp instanceof Date) {
+    return document.timestamp;
+  }
+  if (document.createdAt instanceof Date) {
+    return document.createdAt;
+  }
+  if (document._id instanceof ObjectId) {
+    return document._id.getTimestamp();
+  }
+  return new Date();
+}
+
+function extractValue(document: ParameterDocument, descriptor: ParameterDescriptor): number | null {
+  const candidates = getParameterFieldCandidates({ id: descriptor.id, name: descriptor.name });
+
+  for (const key of candidates) {
+    if (!Object.prototype.hasOwnProperty.call(document, key)) {
+      continue;
+    }
+    const numeric = toFiniteNumber(document[key as keyof ParameterDocument]);
+    if (numeric !== null) {
+      return numeric;
+    }
+  }
+
+  return null;
+}
+
+async function getParameterCollection(
+  dashboard: string,
+): Promise<Collection<ParameterDocument> | null> {
+  if (!isMongoConfigured()) {
+    return null;
+  }
+
+  try {
+    const collectionName = getParameterCollectionName(dashboard);
+    return await getCollection<ParameterDocument>(collectionName);
+  } catch (error) {
+    console.error(`Failed to access MongoDB parameter collection for ${dashboard}:`, error);
+    return null;
+  }
+}
+
+async function fetchSnapshotsFromDatabase(
+  dashboard: string,
+  descriptor: ParameterDescriptor,
+  limit: number,
+): Promise<ParameterSnapshot[]> {
+  const collection = await getParameterCollection(dashboard);
+  if (!collection) {
+    return [];
+  }
+
+  try {
+    const documents = await collection
+      .find({}, { sort: { _id: -1 }, limit: Math.max(limit * 3, limit) })
+      .toArray();
+
+    const snapshots: ParameterSnapshot[] = [];
+
+    for (const document of documents) {
+      const value = extractValue(document, descriptor);
+      if (value === null) {
+        continue;
+      }
+
+      snapshots.push({ timestamp: resolveTimestamp(document), value });
+      if (snapshots.length >= limit) {
+        break;
+      }
+    }
+
+    return snapshots.reverse();
+  } catch (error) {
+    console.error(`Failed to load parameter data for ${dashboard}/${descriptor.id}:`, error);
+    return [];
+  }
+}
+
+function readCachedSnapshots(
+  dashboard: string,
+  descriptor: ParameterDescriptor,
+  limit: number,
+): ParameterSnapshot[] | null {
+  const cached = snapshotCache.get(getCacheKey(dashboard, descriptor));
+  if (!cached || cached.length === 0) {
+    return null;
+  }
+  return cached.slice(-limit);
+}
+
+function writeCachedSnapshots(
+  dashboard: string,
+  descriptor: ParameterDescriptor,
+  snapshots: ParameterSnapshot[],
+): void {
+  snapshotCache.set(getCacheKey(dashboard, descriptor), snapshots.slice(-FALLBACK_HISTORY_LIMIT));
+}
+
+function toLineSeries(snapshots: ParameterSnapshot[]): Array<{ time: number; value: number }> {
+  return snapshots.map((snapshot) => ({
+    time: snapshot.timestamp.getTime(),
+    value: snapshot.value,
+  }));
+}
+
+function toBarSeries(snapshots: ParameterSnapshot[]): Array<{ name: string; value: number }> {
+  return snapshots.map((snapshot, index) => ({
+    name: `Point ${index + 1}`,
+    value: snapshot.value,
+  }));
+}
+
+function toStatPayload(snapshots: ParameterSnapshot[]): { value: number; previousValue: number } {
+  const latest = snapshots.at(-1);
+  const previous = snapshots.at(-2) ?? latest;
+  const latestValue = latest?.value ?? 0;
+  const previousValue = previous?.value ?? latestValue;
+  return { value: latestValue, previousValue };
+}
+
+function getLatestValue(snapshots: ParameterSnapshot[]): number | null {
+  const latest = snapshots.at(-1);
+  return latest ? latest.value : null;
+}
+
+export async function getParameterData(
+  dashboard: string,
+  descriptor: ParameterDescriptor,
+  options: GetParameterDataOptions = {},
+): Promise<unknown | null> {
+  const limit = Math.max(1, options.historyLimit ?? DEFAULT_HISTORY_LIMIT);
+
+  const snapshotsFromDb = await fetchSnapshotsFromDatabase(dashboard, descriptor, limit);
+  if (snapshotsFromDb.length > 0) {
+    writeCachedSnapshots(dashboard, descriptor, snapshotsFromDb);
+  }
+
+  const snapshots =
+    snapshotsFromDb.length > 0
+      ? snapshotsFromDb
+      : readCachedSnapshots(dashboard, descriptor, limit) ?? [];
+
+  if (snapshots.length === 0) {
+    return null;
+  }
+
+  switch (descriptor.displayType) {
+    case 'line':
+      return toLineSeries(snapshots);
+    case 'bar':
+      return toBarSeries(snapshots);
+    case 'stat':
+      return toStatPayload(snapshots);
+    default:
+      return getLatestValue(snapshots);
+  }
+}


### PR DESCRIPTION
## Summary
- add helpers to derive per-dashboard parameter/control collection names and acceptable field aliases
- replace the simulated parameter store with Mongo-backed readers that pull dashboard data and expose it via REST/SSE
- update control state actions to use each dashboard's `[name]_control` collection while keeping client hooks in sync with the new APIs

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cc670085fc8325831efe8948bba7f2