### PR TITLE
Align parameter value key with identifier

### DIFF
--- a/src/actions/data.ts
+++ b/src/actions/data.ts
@@ -17,10 +17,12 @@ export async function getLatestParameterData(
   parameter: ParameterDescriptor,
 ): Promise<unknown> {
   try {
+    // Ensure the identifier aligns with the server default when no override is provided.
+    const valueKey = parameter.valueKey?.trim() || parameter.id;
     const payload = await getParameterData(dashboardName, {
       id: parameter.id,
       displayType: parameter.displayType,
-      valueKey: parameter.valueKey,
+      valueKey,
     });
     return payload;
   } catch (error) {

--- a/src/hooks/use-parameter-data.ts
+++ b/src/hooks/use-parameter-data.ts
@@ -28,7 +28,8 @@ export function useParameterData<T = unknown>(
 
   const parameterId = parameter.id;
   const displayType = parameter.displayType;
-  const valueKey = parameter.name?.trim() ? parameter.name.trim() : parameter.id;
+  // Mirror the server's default identifier so lookups use the persisted key.
+  const valueKey = parameterId;
 
   useEffect(() => {
     let cancelled = false;
@@ -97,9 +98,7 @@ export function useParameterData<T = unknown>(
         window.location.origin,
       );
       url.searchParams.set('displayType', displayType);
-      if (valueKey) {
-        url.searchParams.set('valueKey', valueKey);
-      }
+      url.searchParams.set('valueKey', valueKey);
 
       const source = new EventSource(url.toString());
       eventSource = source;


### PR DESCRIPTION
## Summary
- ensure the parameter data hook always requests and streams values by the parameter id
- align the `getLatestParameterData` server action with the server default identifier handling

## Testing
- npm run lint
- npm run typecheck *(fails: existing MongoDB config helpers expect ObjectId identifiers)*

------
https://chatgpt.com/codex/tasks/task_e_68cf13f0746c8325aac96af9630541e0